### PR TITLE
feat: Replace use of verified_name API with verified_name_history API.

### DIFF
--- a/src/account-settings/AccountSettingsPage.jsx
+++ b/src/account-settings/AccountSettingsPage.jsx
@@ -138,6 +138,20 @@ class AccountSettingsPage extends React.Component {
     })),
   }));
 
+  getMostRecentVerifiedNameRecord = verifiedNameHistory => {
+    if (verifiedNameHistory.length > 0) {
+      return verifiedNameHistory.reduce(
+        (prev, curr) => {
+          const prevDate = new Date(prev.created);
+          const currDate = new Date(curr.created);
+          return currDate > prevDate ? curr : prev;
+        },
+      );
+    }
+
+    return null;
+  }
+
   handleEditableFieldChange = (name, value) => {
     this.props.updateDraft(name, value);
   };
@@ -275,9 +289,10 @@ class AccountSettingsPage extends React.Component {
     // Show State field only if the country is US (could include Canada later)
     const showState = this.props.formValues.country === COUNTRY_WITH_STATES;
 
-    const showVerifiedName = this.props.formValues.verifiedName
-      && this.props.formValues.verifiedName.verified_name_enabled;
-    const showVerifiedApproved = showVerifiedName && this.props.formValues.verifiedName.status === 'approved';
+    const verifiedName = this.getMostRecentVerifiedNameRecord(this.props.formValues.verifiedNameHistory.results);
+    const showVerifiedName = verifiedName
+      && this.props.formValues.verifiedNameHistory.verified_name_enabled;
+    const showVerifiedApproved = showVerifiedName && verifiedName.status === 'approved';
 
     const timeZoneOptions = this.getLocalizedTimeZoneOptions(
       this.props.timeZoneOptions,
@@ -286,7 +301,6 @@ class AccountSettingsPage extends React.Component {
     );
 
     const hasLinkedTPA = findIndex(this.props.tpaProviders, provider => provider.connected) >= 0;
-
     return (
       <>
         <div className="account-section" id="basic-information" ref={this.navLinkRefs['#basic-information']}>
@@ -329,7 +343,7 @@ class AccountSettingsPage extends React.Component {
             <EditableField
               name="verifiedName"
               type="text"
-              value={this.props.formValues.verifiedName.verified_name}
+              value={verifiedName.verified_name}
               label={
                 (
                   <div className="d-flex">
@@ -622,10 +636,16 @@ AccountSettingsPage.propTypes = {
     }),
     state: PropTypes.string,
     shouldDisplayDemographicsSection: PropTypes.bool,
-    verifiedName: PropTypes.shape({
-      verified_name: PropTypes.string,
-      status: PropTypes.string,
+    verifiedNameHistory: PropTypes.shape({
       verified_name_enabled: PropTypes.bool,
+      use_verified_name_for_certs: PropTypes.bool,
+      results: PropTypes.arrayOf(
+        PropTypes.shape({
+          verified_name: PropTypes.string,
+          status: PropTypes.string,
+          verified_name_enabled: PropTypes.bool,
+        }),
+      ),
     }),
   }).isRequired,
   siteLanguage: PropTypes.shape({

--- a/src/account-settings/data/service.js
+++ b/src/account-settings/data/service.js
@@ -189,6 +189,19 @@ export async function getVerifiedName() {
   return data;
 }
 
+export async function getVerifiedNameHistory() {
+  let data;
+  const client = getAuthenticatedHttpClient();
+  try {
+    const requestUrl = `${getConfig().LMS_BASE_URL}/api/edx_name_affirmation/v1/verified_name/history`;
+    ({ data } = await client.get(requestUrl));
+  } catch (error) {
+    return {};
+  }
+
+  return data;
+}
+
 /**
  * A single function to GET everything considered a setting.
  * Currently encapsulates Account, Preferences, Coaching, ThirdPartyAuth, and Demographics
@@ -204,7 +217,7 @@ export async function getSettings(username, userRoles, userId) {
     shouldDisplayDemographicsQuestionsResponse,
     demographics,
     demographicsOptions,
-    verifiedName,
+    verifiedNameHistory,
   ] = await Promise.all([
     getAccount(username),
     getPreferences(username),
@@ -215,7 +228,7 @@ export async function getSettings(username, userRoles, userId) {
     getConfig().ENABLE_DEMOGRAPHICS_COLLECTION && shouldDisplayDemographicsQuestions(),
     getConfig().ENABLE_DEMOGRAPHICS_COLLECTION && getDemographics(userId),
     getConfig().ENABLE_DEMOGRAPHICS_COLLECTION && getDemographicsOptions(),
-    getVerifiedName(),
+    getVerifiedNameHistory(),
   ]);
 
   return {
@@ -228,7 +241,7 @@ export async function getSettings(username, userRoles, userId) {
     shouldDisplayDemographicsSection: shouldDisplayDemographicsQuestionsResponse,
     ...demographics,
     demographicsOptions,
-    verifiedName,
+    verifiedNameHistory,
   };
 }
 


### PR DESCRIPTION
This replaces the use of the verified_name API (`{LMS_BASE}/api/edx_name_affirmation/v1/verified_name`) with the verified_name_history API (`{LMS_BASE}/api/edx_name_affirmation/v1/verified_name/history`). The verified_name API returns the most recent verified name for a learner. However, we need access to the entire learner's verified name history in order to view verified name records with other statuses (i.e. pending, submitted, denied) as well as to be able to display previously verified names in the event that the most recent verified name record is denied.

MST-954 (https://openedx.atlassian.net/browse/MST-954)