### PR TITLE
fix: remove scrollbars from name affirmation modals

### DIFF
--- a/src/account-settings/certificate-preference/CertificatePreference.jsx
+++ b/src/account-settings/certificate-preference/CertificatePreference.jsx
@@ -111,7 +111,7 @@ function CertificatePreference({
             </ModalDialog.Title>
           </ModalDialog.Header>
 
-          <ModalDialog.Body>
+          <ModalDialog.Body className="overflow-hidden">
             <Form.Group className="mb-4">
               <Form.Label>
                 {intl.formatMessage(messages['account.settings.field.name.modal.certificate.select'])}

--- a/src/account-settings/name-change/NameChange.jsx
+++ b/src/account-settings/name-change/NameChange.jsx
@@ -167,7 +167,7 @@ function NameChangeModal({
           </ModalDialog.Title>
         </ModalDialog.Header>
 
-        <ModalDialog.Body>
+        <ModalDialog.Body className="mb-3 overflow-hidden">
           {renderBody()}
         </ModalDialog.Body>
 


### PR DESCRIPTION
Before:
---
![Screen Shot 2021-10-14 at 10 56 43 AM](https://user-images.githubusercontent.com/10442143/137357948-4a7c0ab4-855e-46b3-9568-2470bc486612.png)
![Screen Shot 2021-10-14 at 12 28 27 PM](https://user-images.githubusercontent.com/10442143/137358889-55532f5a-773d-49a3-86c3-8fc9a0f130fa.png)

After:
---
![Screen Shot 2021-10-14 at 10 56 26 AM](https://user-images.githubusercontent.com/10442143/137357978-b7971878-00b6-40e0-a974-1ff1bdd35de5.png)
![Screen Shot 2021-10-14 at 12 28 12 PM](https://user-images.githubusercontent.com/10442143/137358899-45e0f86a-d7fa-43e6-b4a4-af051d58b912.png)