### PR TITLE
fix: allow learners to access IDV by default

### DIFF
--- a/src/id-verification/AccessBlocked.jsx
+++ b/src/id-verification/AccessBlocked.jsx
@@ -17,7 +17,7 @@ function AccessBlocked({ error, intl }) {
     return (
       <FormattedMessage
         id="id.verification.access.blocked.denied"
-        defaultMessage="You cannot verify your identity at this time. If you have yet to activate your account, please check your spam folder for the activation email from {email}."
+        defaultMessage="We cannot verify your identity at this time. If you have yet to activate your account, please check your spam folder for the activation email from {email}."
         description="Text that displays when user is denied from making a request, and to check their email for an activation email."
         values={{
           email: <strong>no-reply@registration.edx.org</strong>,

--- a/src/id-verification/IdVerificationContextProvider.jsx
+++ b/src/id-verification/IdVerificationContextProvider.jsx
@@ -56,7 +56,7 @@ export default function IdVerificationContextProvider({ children }) {
   // this flag ensures that they are directed straight back to the summary panel
   const [reachedSummary, setReachedSummary] = useState(false);
 
-  let canVerify = false;
+  let canVerify = true;
   let error = '';
   let existingIdVerification;
 
@@ -75,8 +75,6 @@ export default function IdVerificationContextProvider({ children }) {
       } else {
         error = ERROR_REASONS.CANNOT_VERIFY;
       }
-    } else if (verifiedNameEnabled) {
-      canVerify = true;
     }
   }
 

--- a/src/id-verification/tests/AccessBlocked.test.jsx
+++ b/src/id-verification/tests/AccessBlocked.test.jsx
@@ -67,7 +67,7 @@ describe('AccessBlocked', () => {
       </Router>
     )));
 
-    const text = screen.getByText(/You cannot verify your identity at this time./);
+    const text = screen.getByText(/We cannot verify your identity at this time./);
 
     expect(text).toBeInTheDocument();
   });


### PR DESCRIPTION
@edx/masters-devs-cosmonauts Please help review

Fixing [MST-1128](https://openedx.atlassian.net/browse/MST-1128)

With this change, I am updating the variable `canVerify` to be defaulted `true`. This way, not many learners will be blocked from IDV in the first place.

