### PR TITLE
build: use shared browserslist config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
         npm: [8.5.0]
         npm-test:
         - i18n_extract
-        - is-es5
         - lint
         - test
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
         npm-test:
         - i18n_extract
         - lint
+        - is-es6
         - test
     steps:
     - uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ tx_url2 = https://www.transifex.com/api/2/project/edx-platform/resource/$(transi
 # This directory must match .babelrc .
 transifex_temp = ./temp/babel-plugin-react-intl
 
-NPM_TESTS=build i18n_extract lint test is-es5
+NPM_TESTS=build i18n_extract lint test
 
 .PHONY: test
 test: $(addprefix test.npm.,$(NPM_TESTS))  ## validate ci suite

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ tx_url2 = https://www.transifex.com/api/2/project/edx-platform/resource/$(transi
 # This directory must match .babelrc .
 transifex_temp = ./temp/babel-plugin-react-intl
 
-NPM_TESTS=build i18n_extract lint test
+NPM_TESTS=build i18n_extract lint test is-es6
 
 .PHONY: test
 test: $(addprefix test.npm.,$(NPM_TESTS))  ## validate ci suite

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "universal-cookie": "4.0.4"
       },
       "devDependencies": {
+        "@edx/browserslist-config": "1.0.0",
         "@edx/frontend-build": "9.1.1",
         "@edx/reactifex": "^1.0.3",
         "@testing-library/jest-dom": "5.15.1",
@@ -2108,6 +2109,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@edx/brand-openedx/-/brand-openedx-1.1.0.tgz",
       "integrity": "sha512-ne2ZKF1r0akkt0rEzCAQAk4cTDTI2GiWCpc+T7ldQpw9X57OnUB16dKsFNe40C9uEjL5h3Ps/ZsFM5dm4cIkEQ=="
+    },
+    "node_modules/@edx/browserslist-config": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@edx/browserslist-config/-/browserslist-config-1.0.0.tgz",
+      "integrity": "sha512-gLAlpz9Y5VruxqiUBTROG7PvouIxoMc6dvhvNpXUDHRN0KEke+zBj+zJ4frL9kGbkeex273nzSazbG42hNDLrg==",
+      "dev": true
     },
     "node_modules/@edx/eslint-config": {
       "version": "2.0.0",
@@ -25663,6 +25670,12 @@
       "version": "npm:@edx/brand-openedx@1.1.0",
       "resolved": "https://registry.npmjs.org/@edx/brand-openedx/-/brand-openedx-1.1.0.tgz",
       "integrity": "sha512-ne2ZKF1r0akkt0rEzCAQAk4cTDTI2GiWCpc+T7ldQpw9X57OnUB16dKsFNe40C9uEjL5h3Ps/ZsFM5dm4cIkEQ=="
+    },
+    "@edx/browserslist-config": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@edx/browserslist-config/-/browserslist-config-1.0.0.tgz",
+      "integrity": "sha512-gLAlpz9Y5VruxqiUBTROG7PvouIxoMc6dvhvNpXUDHRN0KEke+zBj+zJ4frL9kGbkeex273nzSazbG42hNDLrg==",
+      "dev": true
     },
     "@edx/eslint-config": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "fedx-scripts webpack",
     "i18n_extract": "BABEL_ENV=i18n fedx-scripts babel src --quiet > /dev/null",
     "lint": "fedx-scripts eslint --ext .js --ext .jsx .",
+    "is-es6": "es-check es6 ./dist/*.js",
     "snapshot": "fedx-scripts jest --updateSnapshot",
     "start": "fedx-scripts webpack-dev-server --progress",
     "test": "fedx-scripts jest --coverage --passWithNoTests"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "scripts": {
     "build": "fedx-scripts webpack",
     "i18n_extract": "BABEL_ENV=i18n fedx-scripts babel src --quiet > /dev/null",
-    "is-es5": "es-check es5 ./dist/*.js",
     "lint": "fedx-scripts eslint --ext .js --ext .jsx .",
     "snapshot": "fedx-scripts jest --updateSnapshot",
     "start": "fedx-scripts webpack-dev-server --progress",
@@ -25,8 +24,7 @@
     "access": "public"
   },
   "browserslist": [
-    "last 2 versions",
-    "ie 11"
+    "extends @edx/browserslist-config"
   ],
   "dependencies": {
     "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
@@ -80,6 +78,7 @@
     "universal-cookie": "4.0.4"
   },
   "devDependencies": {
+    "@edx/browserslist-config": "1.0.0",
     "@edx/frontend-build": "9.1.1",
     "@edx/reactifex": "^1.0.3",
     "@testing-library/jest-dom": "5.15.1",


### PR DESCRIPTION
* Removes custom `browserslist` configuration in favor of using a [shared configuration](https://github.com/edx/browserslist-config).
* Removes `is-es5` check in CI since ES5 was only needed for IE 11 support which is dropped. The supported browsers defined by the shared configuration all [natively support ES6](https://caniuse.com/?search=es6).

This change reduces the resultant asset bundle size.