### PR TITLE
[MST-1075] Prevent focus jump when taking photo

### DIFF
--- a/src/id-verification/panels/TakeIdPhotoPanel.jsx
+++ b/src/id-verification/panels/TakeIdPhotoPanel.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 
@@ -20,10 +20,17 @@ function TakeIdPhotoPanel(props) {
   const {
     setIdPhotoFile, idPhotoFile, optimizelyExperimentName, shouldUseCamera, setIdPhotoMode,
   } = useContext(IdVerificationContext);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    // This prevents focus switching to the heading when taking a photo
+    setMounted(true);
+  }, []);
 
   return (
     <BasePanel
       name={panelSlug}
+      focusOnMount={!mounted}
       title={shouldUseCamera ? props.intl.formatMessage(messages['id.verification.id.photo.title.camera']) : props.intl.formatMessage(messages['id.verification.id.photo.title.upload'])}
     >
       <div>

--- a/src/id-verification/panels/TakePortraitPhotoPanel.jsx
+++ b/src/id-verification/panels/TakePortraitPhotoPanel.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 
@@ -20,10 +20,17 @@ function TakePortraitPhotoPanel(props) {
   const {
     setFacePhotoFile, facePhotoFile, shouldUseCamera, optimizelyExperimentName, setPortraitPhotoMode,
   } = useContext(IdVerificationContext);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    // This prevents focus switching to the heading when taking a photo
+    setMounted(true);
+  }, []);
 
   return (
     <BasePanel
       name={panelSlug}
+      focusOnMount={!mounted}
       title={shouldUseCamera ? props.intl.formatMessage(messages['id.verification.portrait.photo.title.camera']) : props.intl.formatMessage(messages['id.verification.portrait.photo.title.upload'])}
     >
       <div>


### PR DESCRIPTION
https://openedx.atlassian.net/browse/MST-1075

Before this fix, focus would return to the heading when the user takes an IDV photo, causing the scrollbar to jump to the top of the page. The focus should remain on the photo capture button.