### PR TITLE
perf: preload MFE Config API response in index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,9 @@
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <link rel="shortcut icon" href="<%=htmlWebpackPlugin.options.FAVICON_URL%>" type="image/x-icon" />
+      <% if (process.env.MFE_CONFIG_API_URL) { %>
+        <link rel="preload" href="<%= process.env.MFE_CONFIG_API_URL %>?mfe=<%= process.env.APP_ID %>" as="fetch">
+      <% } %>
       <% if (process.env.OPTIMIZELY_PROJECT_ID) { %>
         <script
           src="<%= process.env.MARKETING_SITE_BASE_URL %>/optimizelyjs/<%= process.env.OPTIMIZELY_PROJECT_ID %>.js"


### PR DESCRIPTION
Recently, a capability was added to this MFE that allows it
to load configuration from the LMS's MFE Config
API instead of requiring it to be baked-in to the webpack
build.

When enabled, though, this capability blocks any render
of the MFE until the Config API responds. So, in order to
minimize the amount of time that the MFE is waiting
on the Config API response, we preload the API
response via a <link> in the <head> section
of index.html, which recommends to the browser
to immediately begin loading the MFE Config API
response as soon as index.html is loaded. Otherwise,
the Config API wouldn't be called until React and
frontend-platform are loaded.