### PR TITLE
fix: prevent users from submitting DOB without update

### DIFF
--- a/src/account-settings/AccountSettingsPage.messages.jsx
+++ b/src/account-settings/AccountSettingsPage.messages.jsx
@@ -276,6 +276,16 @@ const messages = defineMessages({
     defaultMessage: 'Year',
     description: 'Label for account settings year of birth field.',
   },
+  'account.settings.field.dob.month.default': {
+    id: 'account.settings.field.month.year.default',
+    defaultMessage: 'Select month',
+    description: 'Default label for account settings month of birth field.',
+  },
+  'account.settings.field.dob.year.default': {
+    id: 'account.settings.field.dob.year.default',
+    defaultMessage: 'Select year',
+    description: 'Default label for account settings year of birth field.',
+  },
   'account.settings.field.dob.form.button': {
     id: 'account.settings.field.dob.form.button',
     defaultMessage: 'Please confirm your date of birth',

--- a/src/account-settings/DOBForm.jsx
+++ b/src/account-settings/DOBForm.jsx
@@ -3,7 +3,7 @@ import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import {
   Form, StatefulButton, ModalDialog, ActionRow, useToggle, Button,
 } from '@edx/paragon';
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import messages from './AccountSettingsPage.messages';
 import { YEAR_OF_BIRTH_OPTIONS } from './data/constants';
@@ -22,13 +22,23 @@ const DOBModal = (props) => {
 
   // eslint-disable-next-line no-unused-vars
   const [isOpen, open, close, toggle] = useToggle(true, {});
+  const [monthValue, setMonthValue] = useState('');
+  const [yearValue, setYearValue] = useState('');
+
+  const handleChange = (e) => {
+    e.preventDefault();
+
+    if (e.target.name === 'month') {
+      setMonthValue(e.target.value);
+    } else if (e.target.name === 'year') {
+      setYearValue(e.target.value);
+    }
+  };
 
   const handleSubmit = (e) => {
     e.preventDefault();
 
-    const month = e.target.month.value;
-    const year = e.target.year.value;
-    const data = month !== '' && year !== '' ? [{ field_name: 'DOB', field_value: `${year}-${month}` }] : [];
+    const data = monthValue !== '' && yearValue !== '' ? [{ field_name: 'DOB', field_value: `${yearValue}-${monthValue}` }] : [];
     onSubmit('extended_profile', data);
   };
 
@@ -58,7 +68,7 @@ const DOBModal = (props) => {
     if (saveState === 'complete' && isOpen) {
       handleComplete();
     }
-  }, [handleComplete, saveState, isOpen]);
+  }, [handleComplete, saveState, isOpen, monthValue, yearValue]);
 
   return (
     <>
@@ -89,7 +99,9 @@ const DOBModal = (props) => {
               <Form.Control
                 as="select"
                 name="month"
+                onChange={handleChange}
               >
+                <option value="">{intl.formatMessage(messages['account.settings.field.dob.month.default'])}</option>
                 {[...Array(12).keys()].map(month => (
                   <option key={month + 1} value={month + 1}>{month + 1}</option>
                 ))}
@@ -102,7 +114,9 @@ const DOBModal = (props) => {
               <Form.Control
                 as="select"
                 name="year"
+                onChange={handleChange}
               >
+                <option value="">{intl.formatMessage(messages['account.settings.field.dob.year.default'])}</option>
                 {YEAR_OF_BIRTH_OPTIONS.map(year => (
                   <option key={year.value} value={year.value}>{year.label}</option>
                 ))}
@@ -118,11 +132,11 @@ const DOBModal = (props) => {
               </ModalDialog.CloseButton>
               <StatefulButton
                 type="submit"
-                state={saveState}
+                state={!(monthValue && yearValue) ? 'unedited' : saveState}
                 labels={{
                   default: intl.formatMessage(messages['account.settings.editable.field.action.save']),
                 }}
-                disabledStates={[]}
+                disabledStates={['unedited']}
               />
             </ActionRow>
           </ModalDialog.Footer>


### PR DESCRIPTION
# [MST-1722](https://2u-internal.atlassian.net/browse/MST-1722)

Users should be forced to update the DOB form before being allowed to submit. Submission is blocked unless the user picks a valid month and year from each drop down, even in the case where the user re-selects the default "Select month" or "Select year" options.

<img width="606" alt="Screen Shot 2022-12-02 at 2 28 26 PM" src="https://user-images.githubusercontent.com/46360176/205371300-b5123401-19c2-4b17-8729-30e8a3088968.png">

<img width="595" alt="Screen Shot 2022-12-02 at 2 28 37 PM" src="https://user-images.githubusercontent.com/46360176/205371314-1971dc5b-22e9-47a3-a8ae-4aef1d3ab579.png">

<img width="601" alt="Screen Shot 2022-12-02 at 2 28 44 PM" src="https://user-images.githubusercontent.com/46360176/205371332-b0d8207a-b27a-45e6-9637-1e8359a89d4c.png">
