### PR TITLE
fix: added language codes to support affected languages

### DIFF
--- a/src/account-settings/BetaLanguageBanner.jsx
+++ b/src/account-settings/BetaLanguageBanner.jsx
@@ -49,6 +49,9 @@ class BetaLanguageBanner extends React.Component {
 
   render() {
     const savedLanguage = this.getSiteLanguageEntry(this.context.locale);
+    if (!savedLanguage) {
+      return null;
+    }
     const isSavedLanguageReleased = savedLanguage.released === true;
     const noPreviousLanguageSet = this.props.siteLanguage.previousValue === null;
     if (isSavedLanguageReleased || noPreviousLanguageSet) {

--- a/src/account-settings/site-language/constants.js
+++ b/src/account-settings/site-language/constants.js
@@ -69,6 +69,31 @@ const siteLanguageList = [
     name: '中文 (简体)',
     released: true,
   },
+  {
+    code: 'pt',
+    name: 'Português',
+    released: true,
+  },
+  {
+    code: 'it',
+    name: 'Italian',
+    released: true,
+  },
+  {
+    code: 'de',
+    name: 'German',
+    released: true,
+  },
+  {
+    code: 'hi',
+    name: 'Hindi',
+    released: true,
+  },
+  {
+    code: 'fr-ca',
+    name: 'French (CA)',
+    released: true,
+  },
 ];
 
 export default siteLanguageList;


### PR DESCRIPTION
**Ticket**

[Learner Running into "Unexpected Error" when he tried to access Account Settings Page](https://2u-internal.atlassian.net/browse/BOM-3487)

**Related Issue**

[Page crashes when dark lang is set to partially supported language](https://github.com/openedx/frontend-app-account/issues/701)

