### PR TITLE
feat: use `atlas` in `make pull_translations`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ export TRANSIFEX_RESOURCE = frontend-app-account
 transifex_resource = frontend-app-account
 transifex_langs = "ar,de,es_419,fa_IR,fr,fr_CA,hi,it,pt,ru,uk,zh_CN,it_IT,pt_PT,de_DE"
 
+intl_imports = ./node_modules/.bin/intl-imports.js
 transifex_utils = ./node_modules/.bin/transifex-utils.js
 i18n = ./src/i18n
 transifex_input = $(i18n)/transifex_input.json
@@ -50,9 +51,23 @@ push_translations:
 	# Pushing comments to Transifex...
 	./node_modules/@edx/reactifex/bash_scripts/put_comments_v3.sh
 
+ifeq ($(OPENEDX_ATLAS_PULL),)
 # Pulls translations from Transifex.
 pull_translations:
 	tx pull -t -f --mode reviewed --languages=$(transifex_langs)
+else
+# Experimental: OEP-58 Pulls translations using atlas
+pull_translations:
+	rm -rf src/i18n/messages
+	mkdir src/i18n/messages
+	cd src/i18n/messages \
+      && atlas pull --filter=$(transifex_langs) \
+               translations/frontend-component-footer/src/i18n/messages:frontend-component-footer \
+               translations/frontend-component-header/src/i18n/messages:frontend-component-header \
+               translations/frontend-app-account/src/i18n/messages:frontend-app-account
+
+	$(intl_imports) frontend-component-header frontend-component-footer frontend-app-account
+endif
 
 # This target is used by Travis.
 validate-no-uncommitted-package-lock-changes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@edx/brand": "npm:@edx/brand-openedx@1.2.0",
-        "@edx/frontend-component-footer": "11.7.1",
-        "@edx/frontend-component-header": "3.7.1",
-        "@edx/frontend-platform": "2.6.2",
+        "@edx/frontend-component-footer": "11.7.3",
+        "@edx/frontend-component-header": "3.7.3",
+        "@edx/frontend-platform": "4.1.0",
         "@edx/paragon": "20.28.5",
         "@fortawesome/fontawesome-svg-core": "1.2.36",
         "@fortawesome/free-brands-svg-icons": "5.15.4",
@@ -1982,11 +1982,11 @@
       }
     },
     "node_modules/@edx/frontend-component-footer": {
-      "version": "11.7.1",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-component-footer/-/frontend-component-footer-11.7.1.tgz",
-      "integrity": "sha512-vNmAL1SnOvzIFm7TJG/d9KhV+d2O5tVsXUL2/DWKHm4IgkPeCw0nDcljODZLFcMNbT1fUYobmBdKLvNSlT+0XQ==",
+      "version": "11.7.3",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-component-footer/-/frontend-component-footer-11.7.3.tgz",
+      "integrity": "sha512-CSLofrLoCglJTSk9SxdTAF/5nqjlJDcisgzSFj57+ecMcbqCUyZlE7yFxKly3NGMnNw+lXIYr9hps7gpOQMnHg==",
       "dependencies": {
-        "@edx/frontend-platform": "^4.0.1",
+        "@edx/frontend-platform": "^4.1.0",
         "@fortawesome/fontawesome-svg-core": "6.4.0",
         "@fortawesome/free-brands-svg-icons": "6.4.0",
         "@fortawesome/free-regular-svg-icons": "6.4.0",
@@ -1995,8 +1995,8 @@
       },
       "peerDependencies": {
         "prop-types": "^15.5.10",
-        "react": "^16.9.0",
-        "react-dom": "^16.9.0"
+        "react": "^16.9.0 || ^17.0.0",
+        "react-dom": "^16.9.0 || ^17.0.0"
       }
     },
     "node_modules/@edx/frontend-component-footer/node_modules/@edx/frontend-platform": {
@@ -2110,12 +2110,12 @@
       "integrity": "sha512-R7Vytos0gMYuPQTMwnNzvK9PBItNV+Qkm/pvghEZI3j2kMrzZmJlczAgHFmt12VV+IRYQXgTlSGP1PKAsMCIUA=="
     },
     "node_modules/@edx/frontend-component-header": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-component-header/-/frontend-component-header-3.7.1.tgz",
-      "integrity": "sha512-DsSBJqbuzz/9rloh3LmEtHJ2s05Wr7s0kJlpoaq+rRMPx/l6AWFKvlzSHN6c4q4xxj1q267sZUd0aNu7NhRW3w==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-component-header/-/frontend-component-header-3.7.3.tgz",
+      "integrity": "sha512-FbjQ3agHXkZmNzV8cpQg+F3ttvlhqGDnMrxOFuQhb9eFJK48q+L0PhfhCjKx+tPi3aeovtcc0vjG/dzGZs5+Gw==",
       "dependencies": {
-        "@edx/frontend-platform": "^4.0.1",
-        "@edx/paragon": "20.29.0",
+        "@edx/frontend-platform": "^4.1.0",
+        "@edx/paragon": "20.30.1",
         "@fortawesome/fontawesome-svg-core": "6.3.0",
         "@fortawesome/free-brands-svg-icons": "6.3.0",
         "@fortawesome/free-regular-svg-icons": "6.3.0",
@@ -2127,8 +2127,8 @@
       },
       "peerDependencies": {
         "prop-types": "^15.5.10",
-        "react": "^16.9.0",
-        "react-dom": "^16.9.0"
+        "react": "^16.9.0 || ^17.0.0",
+        "react-dom": "^16.9.0 || ^17.0.0"
       }
     },
     "node_modules/@edx/frontend-component-header/node_modules/@edx/frontend-platform": {
@@ -2210,9 +2210,9 @@
       }
     },
     "node_modules/@edx/frontend-component-header/node_modules/@edx/paragon": {
-      "version": "20.29.0",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-20.29.0.tgz",
-      "integrity": "sha512-dKOfFMbtoNIQg9ZKc99qSBE99fQ/M/unyee+vSdzVtSvCEMwfUzdYpYSth6dHuU/lhTJl8gwCjz1y0br2MtKNQ==",
+      "version": "20.30.1",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-20.30.1.tgz",
+      "integrity": "sha512-v3Ek8deZWqVKi3IWP08Mj4egrvbmbqQEyRA6+qazHZdgHJA4qOP1SST42UKd9XxPeRbLWUgaJWd0iBAOAna/gw==",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/react-fontawesome": "^0.1.18",
@@ -2227,6 +2227,7 @@
         "mailto-link": "^2.0.0",
         "prop-types": "^15.8.1",
         "react-bootstrap": "^1.6.5",
+        "react-colorful": "^5.6.1",
         "react-dropzone": "^14.2.1",
         "react-focus-on": "^3.5.4",
         "react-loading-skeleton": "^3.1.0",
@@ -2366,17 +2367,17 @@
       }
     },
     "node_modules/@edx/frontend-platform": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-2.6.2.tgz",
-      "integrity": "sha512-h+gYLkPYw41krGiSGs59o2jaq/g3Yk6ay/3rBq0y1/KM6eeaq/F7o14YOhfTRLTpld9Hg+MPKzfOuHyqQN2TEw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-4.1.0.tgz",
+      "integrity": "sha512-7RzN68zaGJS3JZ2UJNx9UTz/qt+TqPAaF9+ngUEhF1iuZCBqoxW2tSg6splHlzXtW9Xk4xBmx5IbssoZWf57iw==",
       "dependencies": {
         "@cospired/i18n-iso-languages": "2.2.0",
         "@formatjs/intl-pluralrules": "4.3.3",
         "@formatjs/intl-relativetimeformat": "10.0.1",
-        "axios": "0.26.1",
-        "axios-cache-adapter": "2.7.3",
+        "axios": "0.27.2",
+        "axios-cache-interceptor": "0.10.7",
         "form-urlencoded": "4.1.4",
-        "glob": "7.2.0",
+        "glob": "7.2.3",
         "history": "4.10.1",
         "i18n-iso-countries": "4.3.1",
         "jwt-decode": "3.1.2",
@@ -2391,48 +2392,31 @@
         "universal-cookie": "4.0.4"
       },
       "bin": {
+        "intl-imports.js": "i18n/scripts/intl-imports.js",
         "transifex-utils.js": "i18n/scripts/transifex-utils.js"
       },
       "peerDependencies": {
         "@edx/paragon": ">= 10.0.0 < 21.0.0",
         "prop-types": "^15.7.2",
-        "react": "^16.9.0",
-        "react-dom": "^16.9.0",
+        "react": "^16.9.0 || ^17.0.0",
+        "react-dom": "^16.9.0 || ^17.0.0",
         "react-redux": "^7.1.1",
         "react-router-dom": "^5.0.1",
         "redux": "^4.0.4"
       }
     },
     "node_modules/@edx/frontend-platform/node_modules/axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "dependencies": {
-        "follow-redirects": "^1.14.8"
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
       }
     },
     "node_modules/@edx/frontend-platform/node_modules/form-urlencoded": {
       "version": "4.1.4",
       "license": "MIT"
-    },
-    "node_modules/@edx/frontend-platform/node_modules/glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/@edx/new-relic-source-map-webpack-plugin": {
       "version": "1.0.2",
@@ -5965,21 +5949,10 @@
     },
     "node_modules/axios": {
       "version": "0.21.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.14.0"
-      }
-    },
-    "node_modules/axios-cache-adapter": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/axios-cache-adapter/-/axios-cache-adapter-2.7.3.tgz",
-      "integrity": "sha512-A+ZKJ9lhpjthOEp4Z3QR/a9xC4du1ALaAsejgRGrH9ef6kSDxdFrhRpulqsh9khsEnwXxGfgpUuDp1YXMNMEiQ==",
-      "dependencies": {
-        "cache-control-esm": "1.0.0",
-        "md5": "^2.2.1"
-      },
-      "peerDependencies": {
-        "axios": "~0.21.1"
       }
     },
     "node_modules/axios-cache-interceptor": {
@@ -6658,11 +6631,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/cache-control-esm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cache-control-esm/-/cache-control-esm-1.0.0.tgz",
-      "integrity": "sha512-Fa3UV4+eIk4EOih8FTV6EEsVKO0W5XWtNs6FC3InTfVz+EjurjPfDXY5wZDo/lxjDxg5RjNcurLyxEJBcEUx9g=="
-    },
     "node_modules/cache-parser": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/cache-parser/-/cache-parser-1.2.4.tgz",
@@ -6778,14 +6746,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/cheerio": {
@@ -7320,14 +7280,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/css-declaration-sorter": {
@@ -11150,6 +11102,7 @@
     },
     "node_modules/is-buffer": {
       "version": "1.1.6",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-callable": {
@@ -14446,16 +14399,6 @@
         "css-mediaquery": "^0.1.2"
       }
     },
-    "node_modules/md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "dependencies": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
-      }
-    },
     "node_modules/mdn-data": {
       "version": "2.0.14",
       "dev": true,
@@ -16719,6 +16662,15 @@
       },
       "peerDependencies": {
         "react": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-colorful": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
+      "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/react-dev-utils": {

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
   ],
   "dependencies": {
     "@edx/brand": "npm:@edx/brand-openedx@1.2.0",
-    "@edx/frontend-component-footer": "11.7.1",
-    "@edx/frontend-component-header": "3.7.1",
-    "@edx/frontend-platform": "2.6.2",
+    "@edx/frontend-component-footer": "11.7.3",
+    "@edx/frontend-component-header": "3.7.3",
+    "@edx/frontend-platform": "4.1.0",
     "@edx/paragon": "20.28.5",
     "@fortawesome/fontawesome-svg-core": "1.2.36",
     "@fortawesome/free-brands-svg-icons": "5.15.4",

--- a/src/account-settings/delete-account/DeleteAccount.test.jsx
+++ b/src/account-settings/delete-account/DeleteAccount.test.jsx
@@ -4,10 +4,10 @@ import renderer from 'react-test-renderer';
 import { IntlProvider, injectIntl } from '@edx/frontend-platform/i18n';
 
 // Testing the modals separately, they just clutter up the snapshots if included here.
-jest.mock('./ConfirmationModal', () => function () {
+jest.mock('./ConfirmationModal', () => function ConfirmationModalMock() {
   return <></>;
 });
-jest.mock('./SuccessModal', () => function () {
+jest.mock('./SuccessModal', () => function SuccessModalMock() {
   return <></>;
 });
 

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -1,3 +1,6 @@
+import { messages as headerMessages } from '@edx/frontend-component-header';
+import { messages as footerMessages } from '@edx/frontend-component-footer';
+
 import arMessages from './messages/ar.json';
 import deMessages from './messages/de.json';
 import es419Messages from './messages/es_419.json';
@@ -15,7 +18,7 @@ import ititCAMessages from './messages/it_IT.json';
 import ptptCAMessages from './messages/pt_PT.json';
 // no need to import en messages-- they are in the defaultMessage field
 
-const messages = {
+const appMessages = {
   ar: arMessages,
   'es-419': es419Messages,
   'fa-ir': faIRMessages,
@@ -33,4 +36,8 @@ const messages = {
   'pt-pt': ptptCAMessages,
 };
 
-export default messages;
+export default [
+  headerMessages,
+  footerMessages,
+  appMessages,
+];

--- a/src/id-verification/tests/IdVerificationPage.test.jsx
+++ b/src/id-verification/tests/IdVerificationPage.test.jsx
@@ -20,31 +20,31 @@ jest.mock('../VerifiedNameContext', () => {
     VerifiedNameContextProvider: jest.fn(({ children }) => children),
   };
 });
-jest.mock('../panels/ReviewRequirementsPanel', () => function () {
+jest.mock('../panels/ReviewRequirementsPanel', () => function ReviewRequirementsPanelMock() {
   return <></>;
 });
-jest.mock('../panels/RequestCameraAccessPanel', () => function () {
+jest.mock('../panels/RequestCameraAccessPanel', () => function RequestCameraAccessPanelMock() {
   return <></>;
 });
-jest.mock('../panels/PortraitPhotoContextPanel', () => function () {
+jest.mock('../panels/PortraitPhotoContextPanel', () => function PortraitPhotoContextPanelMock() {
   return <></>;
 });
-jest.mock('../panels/TakePortraitPhotoPanel', () => function () {
+jest.mock('../panels/TakePortraitPhotoPanel', () => function TakePortraitPhotoPanelMock() {
   return <></>;
 });
-jest.mock('../panels/IdContextPanel', () => function () {
+jest.mock('../panels/IdContextPanel', () => function IdContextPanelMock() {
   return <></>;
 });
-jest.mock('../panels/GetNameIdPanel', () => function () {
+jest.mock('../panels/GetNameIdPanel', () => function GetNameIdPanelMock() {
   return <></>;
 });
-jest.mock('../panels/TakeIdPhotoPanel', () => function () {
+jest.mock('../panels/TakeIdPhotoPanel', () => function TakeIdPhotoPanelMock() {
   return <></>;
 });
-jest.mock('../panels/SummaryPanel', () => function () {
+jest.mock('../panels/SummaryPanel', () => function SummaryPanelMock() {
   return <></>;
 });
-jest.mock('../panels/SubmittedPanel', () => function () {
+jest.mock('../panels/SubmittedPanel', () => function SubmittedPanelMock() {
   return <></>;
 });
 

--- a/src/id-verification/tests/panels/TakePortraitPhotoPanel.test.jsx
+++ b/src/id-verification/tests/panels/TakePortraitPhotoPanel.test.jsx
@@ -13,7 +13,7 @@ jest.mock('@edx/frontend-platform/analytics', () => ({
   sendTrackEvent: jest.fn(),
 }));
 
-jest.mock('../../Camera', () => function () {
+jest.mock('../../Camera', () => function CameraMock() {
   return <></>;
 });
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -10,14 +10,14 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Route, Switch } from 'react-router-dom';
 
-import Header, { messages as headerMessages } from '@edx/frontend-component-header';
-import Footer, { messages as footerMessages } from '@edx/frontend-component-footer';
+import Header from '@edx/frontend-component-header';
+import Footer from '@edx/frontend-component-footer';
 
 import configureStore from './data/configureStore';
 import AccountSettingsPage, { NotFoundPage } from './account-settings';
 import IdVerificationPage from './id-verification';
 import CoachingConsent from './account-settings/coaching/CoachingConsent';
-import appMessages from './i18n';
+import messages from './i18n';
 
 import './index.scss';
 import Head from './head/Head';
@@ -51,11 +51,7 @@ subscribe(APP_INIT_ERROR, (error) => {
 });
 
 initialize({
-  messages: [
-    appMessages,
-    headerMessages,
-    footerMessages,
-  ],
+  messages,
   requireAuthenticatedUser: true,
   hydrateAuthenticatedUser: true,
   handlers: {


### PR DESCRIPTION
Changes:
-------

 - Bump frontend-platform to bring intl-imports.js script
 - Move all i18n imports into `src/i18n/index.js` so intl-imports.js can override it with latest translations
 - Add `atlas` into `make pull_translations` when `OPENEDX_ATLAS_PULL` environment variable is set.
 - Fixed lint rules for frontend-platform@4.1.0
 
Testing
-------
 - [x] Unblock by having header/footer version bumps in GitHub (need help on that)
 - [x] Test pulled translations
 - [x] Quick QA for translated content (screenshot below): <details><summary>Screenshot</summary>
<kbd>![image](https://user-images.githubusercontent.com/645156/232773201-6bb609db-01a3-4f55-b465-b653e322d1b4.png)</kbd>
</details> 



References
----------

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Check the links above for full information about the overall project.

Internalization is being rearchitected in Open edX Python, XBlock, Micro-frontend, and other projects. There are a number of immediately visible changes:
 - Remove source and language translations from the repositories, hence no `.json`, `.po` or `.mo` files will be committed into the repos.
 - Add standardized `make extract_translations` in all repositories
 - Push user-facing messages strings into [openedx/openedx-translations](https://github.com/openedx/openedx-translations/).
 - Integrate root repositories with [openedx/openedx-atlas](https://github.com/openedx/openedx-atlas/) to pull translations on build/deploy time

Breaking Changes
----------------

One of the primary goals of the project is to **avoid breaking changes**. If you noticed any suspicious code, please raise your concern. But before that, please know the strategy we're following to avoid breaking changes:

**For Micro-frontends:**

 - Legacy hardcoded translations are kept into the repo.
 - Consolodate all i18n imports into `src/i18n/index.js`
 - Add `atlas` integration in `make pull_translations` but only if `OPENEDX_ATLAS_PULL` is set
 - Bump frontend-platform and use `intl-imports.js` to generate up to date import files
 - If translations is missing, they're added according to the latest Micro-frontend i18n pattern in par with https://github.com/openedx/frontend-template-application/

