### PR TITLE
refactor: reverted platform to v2.6 to avoid dependency issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@edx/brand": "npm:@edx/brand-openedx@1.2.0",
-        "@edx/frontend-component-footer": "11.7.2",
-        "@edx/frontend-component-header": "3.7.2",
-        "@edx/frontend-platform": "4.0.2",
+        "@edx/frontend-component-footer": "11.7.1",
+        "@edx/frontend-component-header": "3.7.1",
+        "@edx/frontend-platform": "2.6.2",
         "@edx/paragon": "20.28.5",
         "@fortawesome/fontawesome-svg-core": "1.2.36",
         "@fortawesome/free-brands-svg-icons": "5.15.4",
@@ -1982,9 +1982,9 @@
       }
     },
     "node_modules/@edx/frontend-component-footer": {
-      "version": "11.7.2",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-component-footer/-/frontend-component-footer-11.7.2.tgz",
-      "integrity": "sha512-joyygHAE8kuG50FIjiY8obEG0ARVAVRrJXOiOCHWGfu2Mie02/Rv0lFpwTdeBC0AHS6rnegXSdzhjuVgigyx1A==",
+      "version": "11.7.1",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-component-footer/-/frontend-component-footer-11.7.1.tgz",
+      "integrity": "sha512-vNmAL1SnOvzIFm7TJG/d9KhV+d2O5tVsXUL2/DWKHm4IgkPeCw0nDcljODZLFcMNbT1fUYobmBdKLvNSlT+0XQ==",
       "dependencies": {
         "@edx/frontend-platform": "^4.0.1",
         "@fortawesome/fontawesome-svg-core": "6.4.0",
@@ -1995,8 +1995,47 @@
       },
       "peerDependencies": {
         "prop-types": "^15.5.10",
+        "react": "^16.9.0",
+        "react-dom": "^16.9.0"
+      }
+    },
+    "node_modules/@edx/frontend-component-footer/node_modules/@edx/frontend-platform": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-4.2.0.tgz",
+      "integrity": "sha512-iDoFeccENQKBjqUgdjl5KSwBrjNEj8YW6Ual+6twcHHJUBg3yRoBEphwHIoRREcMgQjhdKVAdWj8eleh4JsEKA==",
+      "dependencies": {
+        "@cospired/i18n-iso-languages": "2.2.0",
+        "@formatjs/intl-pluralrules": "4.3.3",
+        "@formatjs/intl-relativetimeformat": "10.0.1",
+        "axios": "0.27.2",
+        "axios-cache-interceptor": "0.10.7",
+        "form-urlencoded": "4.1.4",
+        "glob": "7.2.3",
+        "history": "4.10.1",
+        "i18n-iso-countries": "4.3.1",
+        "jwt-decode": "3.1.2",
+        "localforage": "1.10.0",
+        "localforage-memoryStorageDriver": "0.9.2",
+        "lodash.camelcase": "4.3.0",
+        "lodash.memoize": "4.1.2",
+        "lodash.merge": "4.6.2",
+        "lodash.snakecase": "4.1.1",
+        "pubsub-js": "1.9.4",
+        "react-intl": "^5.25.0",
+        "universal-cookie": "4.0.4"
+      },
+      "bin": {
+        "intl-imports.js": "i18n/scripts/intl-imports.js",
+        "transifex-utils.js": "i18n/scripts/transifex-utils.js"
+      },
+      "peerDependencies": {
+        "@edx/paragon": ">= 10.0.0 < 21.0.0",
+        "prop-types": "^15.7.2",
         "react": "^16.9.0 || ^17.0.0",
-        "react-dom": "^16.9.0 || ^17.0.0"
+        "react-dom": "^16.9.0 || ^17.0.0",
+        "react-redux": "^7.1.1",
+        "react-router-dom": "^5.0.1",
+        "redux": "^4.0.4"
       }
     },
     "node_modules/@edx/frontend-component-footer/node_modules/@fortawesome/fontawesome-common-types": {
@@ -2056,13 +2095,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/@edx/frontend-component-footer/node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@edx/frontend-component-footer/node_modules/form-urlencoded": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/form-urlencoded/-/form-urlencoded-4.1.4.tgz",
+      "integrity": "sha512-R7Vytos0gMYuPQTMwnNzvK9PBItNV+Qkm/pvghEZI3j2kMrzZmJlczAgHFmt12VV+IRYQXgTlSGP1PKAsMCIUA=="
+    },
     "node_modules/@edx/frontend-component-header": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-component-header/-/frontend-component-header-3.7.2.tgz",
-      "integrity": "sha512-tUGatyYfFB5bKg+iqbFfvRNtvLM54A7WlRKWQ4dY3iIjcMDCD99CcdfqGup3gbIMIBehS14o0skDs2J8R3OElw==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-component-header/-/frontend-component-header-3.7.1.tgz",
+      "integrity": "sha512-DsSBJqbuzz/9rloh3LmEtHJ2s05Wr7s0kJlpoaq+rRMPx/l6AWFKvlzSHN6c4q4xxj1q267sZUd0aNu7NhRW3w==",
       "dependencies": {
         "@edx/frontend-platform": "^4.0.1",
-        "@edx/paragon": "20.30.1",
+        "@edx/paragon": "20.29.0",
         "@fortawesome/fontawesome-svg-core": "6.3.0",
         "@fortawesome/free-brands-svg-icons": "6.3.0",
         "@fortawesome/free-regular-svg-icons": "6.3.0",
@@ -2074,14 +2127,92 @@
       },
       "peerDependencies": {
         "prop-types": "^15.5.10",
+        "react": "^16.9.0",
+        "react-dom": "^16.9.0"
+      }
+    },
+    "node_modules/@edx/frontend-component-header/node_modules/@edx/frontend-platform": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-4.2.0.tgz",
+      "integrity": "sha512-iDoFeccENQKBjqUgdjl5KSwBrjNEj8YW6Ual+6twcHHJUBg3yRoBEphwHIoRREcMgQjhdKVAdWj8eleh4JsEKA==",
+      "dependencies": {
+        "@cospired/i18n-iso-languages": "2.2.0",
+        "@formatjs/intl-pluralrules": "4.3.3",
+        "@formatjs/intl-relativetimeformat": "10.0.1",
+        "axios": "0.27.2",
+        "axios-cache-interceptor": "0.10.7",
+        "form-urlencoded": "4.1.4",
+        "glob": "7.2.3",
+        "history": "4.10.1",
+        "i18n-iso-countries": "4.3.1",
+        "jwt-decode": "3.1.2",
+        "localforage": "1.10.0",
+        "localforage-memoryStorageDriver": "0.9.2",
+        "lodash.camelcase": "4.3.0",
+        "lodash.memoize": "4.1.2",
+        "lodash.merge": "4.6.2",
+        "lodash.snakecase": "4.1.1",
+        "pubsub-js": "1.9.4",
+        "react-intl": "^5.25.0",
+        "universal-cookie": "4.0.4"
+      },
+      "bin": {
+        "intl-imports.js": "i18n/scripts/intl-imports.js",
+        "transifex-utils.js": "i18n/scripts/transifex-utils.js"
+      },
+      "peerDependencies": {
+        "@edx/paragon": ">= 10.0.0 < 21.0.0",
+        "prop-types": "^15.7.2",
         "react": "^16.9.0 || ^17.0.0",
-        "react-dom": "^16.9.0 || ^17.0.0"
+        "react-dom": "^16.9.0 || ^17.0.0",
+        "react-redux": "^7.1.1",
+        "react-router-dom": "^5.0.1",
+        "redux": "^4.0.4"
+      }
+    },
+    "node_modules/@edx/frontend-component-header/node_modules/@edx/frontend-platform/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@edx/frontend-component-header/node_modules/@edx/frontend-platform/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@edx/frontend-component-header/node_modules/@edx/frontend-platform/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@edx/frontend-component-header/node_modules/@edx/paragon": {
-      "version": "20.30.1",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-20.30.1.tgz",
-      "integrity": "sha512-v3Ek8deZWqVKi3IWP08Mj4egrvbmbqQEyRA6+qazHZdgHJA4qOP1SST42UKd9XxPeRbLWUgaJWd0iBAOAna/gw==",
+      "version": "20.29.0",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-20.29.0.tgz",
+      "integrity": "sha512-dKOfFMbtoNIQg9ZKc99qSBE99fQ/M/unyee+vSdzVtSvCEMwfUzdYpYSth6dHuU/lhTJl8gwCjz1y0br2MtKNQ==",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/react-fontawesome": "^0.1.18",
@@ -2096,7 +2227,6 @@
         "mailto-link": "^2.0.0",
         "prop-types": "^15.8.1",
         "react-bootstrap": "^1.6.5",
-        "react-colorful": "^5.6.1",
         "react-dropzone": "^14.2.1",
         "react-focus-on": "^3.5.4",
         "react-loading-skeleton": "^3.1.0",
@@ -2184,6 +2314,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/@edx/frontend-component-header/node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
     "node_modules/@edx/frontend-component-header/node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -2191,6 +2330,11 @@
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
+    },
+    "node_modules/@edx/frontend-component-header/node_modules/form-urlencoded": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/form-urlencoded/-/form-urlencoded-4.1.4.tgz",
+      "integrity": "sha512-R7Vytos0gMYuPQTMwnNzvK9PBItNV+Qkm/pvghEZI3j2kMrzZmJlczAgHFmt12VV+IRYQXgTlSGP1PKAsMCIUA=="
     },
     "node_modules/@edx/frontend-component-header/node_modules/glob": {
       "version": "8.1.0",
@@ -2222,16 +2366,17 @@
       }
     },
     "node_modules/@edx/frontend-platform": {
-      "version": "4.0.2",
-      "license": "AGPL-3.0",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-2.6.2.tgz",
+      "integrity": "sha512-h+gYLkPYw41krGiSGs59o2jaq/g3Yk6ay/3rBq0y1/KM6eeaq/F7o14YOhfTRLTpld9Hg+MPKzfOuHyqQN2TEw==",
       "dependencies": {
         "@cospired/i18n-iso-languages": "2.2.0",
         "@formatjs/intl-pluralrules": "4.3.3",
         "@formatjs/intl-relativetimeformat": "10.0.1",
-        "axios": "0.27.2",
-        "axios-cache-interceptor": "0.10.7",
+        "axios": "0.26.1",
+        "axios-cache-adapter": "2.7.3",
         "form-urlencoded": "4.1.4",
-        "glob": "7.2.3",
+        "glob": "7.2.0",
         "history": "4.10.1",
         "i18n-iso-countries": "4.3.1",
         "jwt-decode": "3.1.2",
@@ -2259,16 +2404,35 @@
       }
     },
     "node_modules/@edx/frontend-platform/node_modules/axios": {
-      "version": "0.27.2",
-      "license": "MIT",
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
       "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
+        "follow-redirects": "^1.14.8"
       }
     },
     "node_modules/@edx/frontend-platform/node_modules/form-urlencoded": {
       "version": "4.1.4",
       "license": "MIT"
+    },
+    "node_modules/@edx/frontend-platform/node_modules/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/@edx/new-relic-source-map-webpack-plugin": {
       "version": "1.0.2",
@@ -5801,15 +5965,27 @@
     },
     "node_modules/axios": {
       "version": "0.21.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.14.0"
       }
     },
+    "node_modules/axios-cache-adapter": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/axios-cache-adapter/-/axios-cache-adapter-2.7.3.tgz",
+      "integrity": "sha512-A+ZKJ9lhpjthOEp4Z3QR/a9xC4du1ALaAsejgRGrH9ef6kSDxdFrhRpulqsh9khsEnwXxGfgpUuDp1YXMNMEiQ==",
+      "dependencies": {
+        "cache-control-esm": "1.0.0",
+        "md5": "^2.2.1"
+      },
+      "peerDependencies": {
+        "axios": "~0.21.1"
+      }
+    },
     "node_modules/axios-cache-interceptor": {
       "version": "0.10.7",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/axios-cache-interceptor/-/axios-cache-interceptor-0.10.7.tgz",
+      "integrity": "sha512-UjpxChG5DpF6Kf1IPGMLOzRDNL8ZNS6TOn1jTaVvCE7cWFU904jJwi0T1s+IbijpnLEjK2iq5uLIuR8Sj+RsFQ==",
       "dependencies": {
         "cache-parser": "^1.2.4",
         "fast-defer": "^1.1.7",
@@ -6482,9 +6658,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/cache-control-esm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cache-control-esm/-/cache-control-esm-1.0.0.tgz",
+      "integrity": "sha512-Fa3UV4+eIk4EOih8FTV6EEsVKO0W5XWtNs6FC3InTfVz+EjurjPfDXY5wZDo/lxjDxg5RjNcurLyxEJBcEUx9g=="
+    },
     "node_modules/cache-parser": {
       "version": "1.2.4",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/cache-parser/-/cache-parser-1.2.4.tgz",
+      "integrity": "sha512-O0KwuHuJnbHUrghHi2kGp0SxnWSIBXTYt7M8WVhW0kbPRUNUKoE/Of6e1rRD6AAxmfxFunKnt90yEK09D+sc5g=="
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
@@ -6596,6 +6778,14 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/cheerio": {
@@ -7130,6 +7320,14 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/css-declaration-sorter": {
@@ -9321,7 +9519,8 @@
     },
     "node_modules/fast-defer": {
       "version": "1.1.7",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/fast-defer/-/fast-defer-1.1.7.tgz",
+      "integrity": "sha512-tJ01ulDWT2WhqxMKS20nXX6wyX2iInBYpbN3GO7yjKwXMY4qvkdBRxak9IFwBLlFDESox+SwSvqMCZDfe1tqeg=="
     },
     "node_modules/fast-glob": {
       "version": "3.2.12",
@@ -9801,7 +10000,8 @@
     },
     "node_modules/form-data": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -10950,7 +11150,6 @@
     },
     "node_modules/is-buffer": {
       "version": "1.1.6",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-callable": {
@@ -14247,6 +14446,16 @@
         "css-mediaquery": "^0.1.2"
       }
     },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.0.14",
       "dev": true,
@@ -14825,7 +15034,8 @@
     },
     "node_modules/object-code": {
       "version": "1.2.4",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/object-code/-/object-code-1.2.4.tgz",
+      "integrity": "sha512-uGq4ETUuWe+GA586NXEriiaozNuff+YNFXlpD8cVrM1GoiuTZpCABP+bZCWDrvQDoCiSTyiWAFHD/HF/iwhb2w=="
     },
     "node_modules/object-copy": {
       "version": "0.1.0",
@@ -16509,15 +16719,6 @@
       },
       "peerDependencies": {
         "react": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/react-colorful": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
-      "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/react-dev-utils": {

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
   ],
   "dependencies": {
     "@edx/brand": "npm:@edx/brand-openedx@1.2.0",
-    "@edx/frontend-component-footer": "11.7.2",
-    "@edx/frontend-component-header": "3.7.2",
-    "@edx/frontend-platform": "4.0.2",
+    "@edx/frontend-component-footer": "11.7.1",
+    "@edx/frontend-component-header": "3.7.1",
+    "@edx/frontend-platform": "2.6.2",
     "@edx/paragon": "20.28.5",
     "@fortawesome/fontawesome-svg-core": "1.2.36",
     "@fortawesome/free-brands-svg-icons": "5.15.4",


### PR DESCRIPTION
# Description
Reverted `frontend-platform `version since v4 is causing dependency issues & we are unable to update the `edx-internal` until `header-edx` PR is merged which is dependent on enterprise node v18 upgrade (currently blocked due to enterprise lerna issue)