### PR TITLE
refactor: update notEditable to nonEditable in notification preferences

### DIFF
--- a/src/notification-preferences/NotificationPreferences.test.jsx
+++ b/src/notification-preferences/NotificationPreferences.test.jsx
@@ -58,7 +58,7 @@ const defaultPreferences = {
       mobile: false,
     },
   ],
-  notEditable: {},
+  nonEditable: {},
 };
 
 const setupStore = (override = {}) => {

--- a/src/notification-preferences/data/reducers.js
+++ b/src/notification-preferences/data/reducers.js
@@ -17,7 +17,7 @@ export const defaultState = {
     selectedCourse: null,
     preferences: [],
     apps: [],
-    notEditable: {},
+    nonEditable: {},
   },
 };
 
@@ -59,7 +59,7 @@ const notificationPreferencesReducer = (state = defaultState, action = {}) => {
           status: LOADING_STATUS,
           preferences: [],
           apps: [],
-          notEditable: {},
+          nonEditable: {},
         },
       };
     case Actions.FETCHED_PREFERENCES:
@@ -79,7 +79,7 @@ const notificationPreferencesReducer = (state = defaultState, action = {}) => {
           status: FAILURE_STATUS,
           preferences: [],
           apps: [],
-          notEditable: {},
+          nonEditable: {},
         },
       };
     case Actions.UPDATE_SELECTED_COURSE:

--- a/src/notification-preferences/data/reducers.test.js
+++ b/src/notification-preferences/data/reducers.test.js
@@ -20,7 +20,7 @@ describe('notification-preferences reducer', () => {
       push: false,
       mobile: false,
     }],
-    notEditable: {},
+    nonEditable: {},
   };
 
   beforeEach(() => {
@@ -98,7 +98,7 @@ describe('notification-preferences reducer', () => {
       selectedCourse: null,
       preferences: [],
       apps: [],
-      notEditable: {},
+      nonEditable: {},
     });
   });
 

--- a/src/notification-preferences/data/selectors.js
+++ b/src/notification-preferences/data/selectors.js
@@ -47,7 +47,7 @@ export const selectPreference = (appId, name) => state => (
 );
 
 export const selectPreferenceNonEditableChannels = (appId, name) => state => (
-  state?.notificationPreferences.preferences.notEditable[appId]?.[name] || []
+  state?.notificationPreferences.preferences.nonEditable[appId]?.[name] || []
 );
 
 export const selectSelectedCourseId = () => state => (

--- a/src/notification-preferences/data/thunks.js
+++ b/src/notification-preferences/data/thunks.js
@@ -45,7 +45,7 @@ const normalizePreferences = (responseData) => {
     enabled: preferences[appId].enabled,
   }));
 
-  const notEditable = {};
+  const nonEditable = {};
   const preferenceList = appKeys.map(appId => {
     const preferencesKeys = Object.keys(preferences[appId].notificationTypes);
     const flatPreferences = preferencesKeys.map(preferenceId => (
@@ -58,8 +58,7 @@ const normalizePreferences = (responseData) => {
         info: preferences[appId].notificationTypes[preferenceId].info || '',
       }
     ));
-
-    notEditable[appId] = preferences[appId].notEditable;
+    nonEditable[appId] = preferences[appId].nonEditable;
 
     return flatPreferences;
   }).flat();
@@ -67,7 +66,7 @@ const normalizePreferences = (responseData) => {
   const normalizedPreferences = {
     apps,
     preferences: preferenceList,
-    notEditable,
+    nonEditable,
   };
   return normalizedPreferences;
 };

--- a/src/notification-preferences/messages.js
+++ b/src/notification-preferences/messages.js
@@ -24,8 +24,8 @@ export const messages = defineMessages({
         core {Core}
         newPost {New Post}
         newComment {New Comment}
+        newResponse {New Response}
         newCommentOnPost {New Comment On Post}
-        newResponseOnPost {New Response On Post}
         newResponseOnComment {New Response On Comment}
         newAssignment {New Assignment}
         newGrade {New Grade}


### PR DESCRIPTION
### [INF-948](https://2u-internal.atlassian.net/browse/INF-948)

- Make the core notification toggle disable according to nonEditable.
<img width="573" alt="Screenshot 2023-07-10 at 6 15 22 PM" src="https://github.com/openedx/frontend-app-account/assets/79941147/148820e6-b357-4825-af83-4ac269680c56">
