### PR TITLE
fix: honor account deletion feature flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ temp/babel-plugin-react-intl
 /temp
 /.vscode
 /module.config.js
+/src/account-settings/JumpNav.jsx

--- a/src/account-settings/AccountSettingsPage.jsx
+++ b/src/account-settings/AccountSettingsPage.jsx
@@ -777,12 +777,15 @@ class AccountSettingsPage extends React.Component {
           <ThirdPartyAuth />
         </div>
 
-        <div className="account-section pt-3 mb-5" id="delete-account" ref={this.navLinkRefs['#delete-account']}>
-          <DeleteAccount
-            isVerifiedAccount={this.props.isActive}
-            hasLinkedTPA={hasLinkedTPA}
-          />
-        </div>
+        {this.props.formValues.enable_account_deletion 
+          && (
+          <div className="account-section pt-3 mb-5" id="delete-account" ref={this.navLinkRefs['#delete-account']}>
+            <DeleteAccount
+              isVerifiedAccount={this.props.isActive}
+              hasLinkedTPA={hasLinkedTPA}
+              />
+          </div>
+          )}
 
       </>
     );
@@ -822,6 +825,7 @@ class AccountSettingsPage extends React.Component {
             <div className="col-md-2">
               <JumpNav
                 displayDemographicsLink={this.props.formValues.shouldDisplayDemographicsSection}
+                displayAccountDeletion={this.props.formValues.enable_account_deletion}
               />
             </div>
             <div className="col-md-10">
@@ -871,6 +875,7 @@ AccountSettingsPage.propTypes = {
     shouldDisplayDemographicsSection: PropTypes.bool,
     useVerifiedNameForCerts: PropTypes.bool.isRequired,
     verified_name: PropTypes.string,
+    enable_account_deletion: PropTypes.bool,
   }).isRequired,
   committedValues: PropTypes.shape({
     name: PropTypes.string,

--- a/src/account-settings/JumpNav.jsx
+++ b/src/account-settings/JumpNav.jsx
@@ -13,6 +13,7 @@ import messages from './AccountSettingsPage.messages';
 const JumpNav = ({
   intl,
   displayDemographicsLink,
+  displayAccountDeletion
 }) => {
   const stickToTop = useWindowSize().width > breakpoints.small.minWidth;
   const showNotificationMenu = false;
@@ -64,11 +65,14 @@ const JumpNav = ({
             {intl.formatMessage(messages['account.settings.section.linked.accounts'])}
           </NavHashLink>
         </li>
-        <li>
-          <NavHashLink to="#delete-account">
-            {intl.formatMessage(messages['account.settings.jump.nav.delete.account'])}
-          </NavHashLink>
-        </li>
+        {displayAccountDeletion 
+          && (
+          <li>
+            <NavHashLink to="#delete-account">
+              {intl.formatMessage(messages['account.settings.jump.nav.delete.account'])}
+            </NavHashLink>
+          </li>
+          )}
       </Scrollspy>
       {showNotificationMenu
         && (


### PR DESCRIPTION
Issue - [There is no way to disable account deletion in the Account MFE](https://github.com/openedx/wg-build-test-release/issues/189)

The issue can be solved as follows:

1. The first step involves updating the User Profile API to include the account deletion (`ENABLE_ACCOUNT_DELETION) feature flag.

2. Once the User Profile API is updated, the application needs to use the value of the `enable_account_deletion` flag appropriately to enable or disable the account deletion feature as needed.