### PR TITLE
feat: Added link to documentation on preferences UI

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -73,6 +73,17 @@ $fa-font-path: "~font-awesome/fonts";
   padding-left: 0.625rem;
 }
 
+.notification-sub-heading {
+  font-size: 14px;
+  line-height: 28px;
+}
+
+.notification-launch-icon {
+  vertical-align: middle;
+  height: 16px;
+  width: 16px;
+}
+
 .notification-preferences {
   input[type="checkbox"] {
     margin-right: 0;

--- a/src/notification-preferences/NotificationPreferences.jsx
+++ b/src/notification-preferences/NotificationPreferences.jsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Link, useParams } from 'react-router-dom';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { Container, Icon, Spinner } from '@edx/paragon';
-import { ArrowBack } from '@edx/paragon/icons';
+import { ArrowBack, Launch } from '@edx/paragon/icons';
 import {
   selectCourseListStatus,
   selectCourse,
@@ -56,9 +56,20 @@ const NotificationPreferences = () => {
 
   return (
     <Container size="sm" className="notification-preferences">
-      <h2 className="notification-heading mt-6 mb-5.5">
+      <h2 className="notification-heading mt-6 mb-4.5">
         {intl.formatMessage(messages.notificationHeading)}
       </h2>
+      <div className="mb-6 text-gray-700">
+        Notifications for certain activities are enabled by default, {' '}
+        <a
+          className="w-100"
+          target="_blank"
+          href="https://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/sfd_notifications/managing_notifications.html"
+          rel="noreferrer"
+        >
+          as detailed here <Icon className="d-inline-block notification-launch-icon" src={Launch} />
+        </a>
+      </div>
       <div className="h-100">
         <div className="d-flex mb-5">
           <Link to="/notifications">


### PR DESCRIPTION
[INF-1016](https://2u-internal.atlassian.net/browse/INF-1016)

**Description**
As per requirement from the privacy team, we added the following text on the preferences page, as shown in this mockup: https://www.figma.com/file/1WsIDaf9Alfy2r8eNYj6vX/Notifications?type=design&node-id=594-15747&mode=design&t=nMhhVBzBChGFELzX-4 .

“Notifications for certain activities are enabled by default, as detailed here.”

**Screenshot**
<img width="629" alt="Screenshot 2023-09-05 at 1 49 11 PM" src="https://github.com/openedx/frontend-app-account/assets/72802712/513c2663-a68f-4dac-95a3-4f2fd8182ceb">
