### PR TITLE
fix: Add ID attribute to the main content

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -33,7 +33,7 @@ subscribe(APP_READY, () => {
         <Route element={(
           <div className="d-flex flex-column" style={{ minHeight: '100vh' }}>
             <Header />
-            <main className="flex-grow-1">
+            <main className="flex-grow-1" id="main">
               <Outlet />
             </main>
             <Footer />


### PR DESCRIPTION
Added the missing 'ID' parameter for the main section. When we want to use keyboard navigation through the page, the first anchor we encounter on the account page is 'Skip to main content,' which allows us to skip the header and move to the content area. However, this anchor is linked to the #main ID, which is missing in the main section.

Before fix:

https://github.com/openedx/frontend-app-account/assets/19806032/78bb15d0-39f9-4997-a397-59883fc75765

After:

https://github.com/openedx/frontend-app-account/assets/19806032/4479e948-af9f-45be-8a3e-a6e81eb99db1
