### PR TITLE
fix: Fixed the display of the selection of available time zones (for Palm)

### DIFF
--- a/src/account-settings/EditableSelectField.jsx
+++ b/src/account-settings/EditableSelectField.jsx
@@ -98,9 +98,29 @@ const EditableSelectField = (props) => {
       value: confirmationValue,
     });
   };
-  const selectOptions = options.map(option => (
-    <option value={option.value} key={`${option.value}-${option.label}`}>{option.label}</option>
-  ));
+
+  const selectOptions = options.map((option) => {
+    if (option.group) {
+      // If the option has a 'group' property, it represents an element with sub-options.
+      return (
+        <optgroup label={option.label} key={option.label}>
+          {option.group.map((subOption) => (
+            <option
+              value={subOption.value}
+              key={`${subOption.value}-${subOption.label}`}
+            >
+              {subOption.label}
+            </option>
+          ))}
+        </optgroup>
+      );
+    }
+    return (
+      <option value={option.value} key={`${option.value}-${option.label}`}>
+        {option.label}
+      </option>
+    );
+  });
 
   return (
     <SwitchContent

--- a/src/account-settings/test/EditableSelectField.test.jsx
+++ b/src/account-settings/test/EditableSelectField.test.jsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { Router } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import { render, screen } from '@testing-library/react';
+import configureStore from 'redux-mock-store';
+import { createMemoryHistory } from 'history';
+
+import { IntlProvider, injectIntl } from '@edx/frontend-platform/i18n';
+
+import EditableSelectField from '../EditableSelectField';
+
+const mockDispatch = jest.fn();
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: () => mockDispatch,
+}));
+
+jest.mock('@edx/frontend-platform/auth');
+jest.mock('../data/selectors', () => jest.fn().mockImplementation(() => ({ certPreferenceSelector: () => ({}) })));
+
+const history = createMemoryHistory();
+
+const IntlEditableSelectField = injectIntl(EditableSelectField);
+
+const mockStore = configureStore();
+
+describe('EditableSelectField', () => {
+  let props = {};
+  let store = {};
+
+  const reduxWrapper = children => (
+    <Router history={history}>
+      <IntlProvider locale="en">
+        <Provider store={store}>{children}</Provider>
+      </IntlProvider>
+    </Router>
+  );
+
+  beforeEach(() => {
+    store = mockStore();
+    props = {
+      name: 'testField',
+      label: 'Main Label',
+      emptyLabel: 'Empty Main Label',
+      type: 'text',
+      value: 'Test Field',
+      userSuppliedValue: '',
+      options: [
+        {
+          label: 'Default Option',
+          value: 'defaultOption',
+        },
+        {
+          label: 'User Options',
+          group: [
+            {
+              label: 'Suboption 1',
+              value: 'suboption1',
+            },
+          ],
+        },
+        {
+          label: 'Other Options',
+          group: [
+            {
+              label: 'Suboption 2',
+              value: 'suboption2',
+            },
+            {
+              label: 'Suboption 3',
+              value: 'suboption3',
+            },
+          ],
+        },
+      ],
+      saveState: 'default',
+      error: '',
+      confirmationMessageDefinition: {
+        id: 'confirmationMessageId',
+        defaultMessage: 'Default Confirmation Message',
+        description: 'Description of the confirmation message',
+      },
+      confirmationValue: 'Confirmation Value',
+      helpText: 'Helpful Text',
+      isEditing: false,
+      isEditable: true,
+      isGrayedOut: false,
+    };
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('renders EditableSelectField correctly with editing disabled', () => {
+    render(reduxWrapper(<IntlEditableSelectField {...props} />));
+
+    expect(screen.getByText('Main Label')).toBeInTheDocument();
+    expect(screen.getByText('Edit')).toBeInTheDocument();
+  });
+
+  it('renders EditableSelectField correctly with editing enabled', () => {
+    props = {
+      ...props,
+      isEditing: true,
+    };
+
+    render(reduxWrapper(<IntlEditableSelectField {...props} />));
+
+    expect(screen.getByText('Main Label')).toBeInTheDocument();
+    expect(screen.getByText('Suboption 1')).toBeInTheDocument();
+    expect(screen.getByText('Default Option')).toBeInTheDocument();
+    expect(screen.getByText('Save')).toBeInTheDocument();
+    expect(screen.getByText('Cancel')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Backport from the [master](https://github.com/openedx/frontend-app-account/pull/896).

### Description

An error was found when selecting a timezone in the user account.

In this [PR](https://github.com/openedx/frontend-app-account/pull/27), a time zone selection was added.
Then the select field was rewritten in [PR](https://github.com/openedx/frontend-app-account/pull/612). (Paragon form component deprecations)
However, these changes have broken the time zone selection field.

#### Before:

<img width="1646" alt="screen_91" src="https://github.com/openedx/frontend-app-account/assets/98233552/815babd5-5b34-4b52-b4c6-eb52c9db0a03">

<img width="1188" alt="screen_94" src="https://github.com/openedx/frontend-app-account/assets/98233552/4d95bc92-e4fd-45a0-a9bc-ecbf9fd67d63">

#### After:

<img width="1655" alt="screen_92" src="https://github.com/openedx/frontend-app-account/assets/98233552/aa446389-e25f-4dae-b213-b01f8a2e6f58">

<img width="1386" alt="screen_93" src="https://github.com/openedx/frontend-app-account/assets/98233552/dc262bfc-ce75-4243-8af2-86e674d4e2ad">
