### PR TITLE
fix: Correction to the language code for Português, Italian and German

### DIFF
--- a/src/account-settings/site-language/constants.js
+++ b/src/account-settings/site-language/constants.js
@@ -75,17 +75,17 @@ const siteLanguageList = [
     released: true,
   },
   {
-    code: 'pt',
+    code: 'pt-pt',
     name: 'Português',
     released: true,
   },
   {
-    code: 'it',
+    code: 'it-it',
     name: 'Italian',
     released: true,
   },
   {
-    code: 'de',
+    code: 'de-de',
     name: 'German',
     released: true,
   },


### PR DESCRIPTION
Started researching into this issues because of this issue:
https://github.com/openedx/wg-build-test-release/issues/267 

For a few languages we have multiple files:

missing translation:

- https://github.com/openedx/frontend-app-account/blob/open-release/palm.master/src/i18n/messages/de.json
- https://github.com/openedx/frontend-app-account/blob/open-release/palm.master/src/i18n/messages/it.json

proper translation:

- https://github.com/openedx/frontend-app-account/blob/open-release/palm.master/src/i18n/messages/de_DE.json
- https://github.com/openedx/frontend-app-account/blob/open-release/palm.master/src/i18n/messages/it_IT.json

This PR adds the correct one in the options