### PR TITLE
chore: bump frontend-platform

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@edx/brand": "npm:@edx/brand-openedx@1.2.0",
         "@edx/frontend-component-footer": "12.3.0",
         "@edx/frontend-component-header": "4.7.0",
-        "@edx/frontend-platform": "5.4.0",
+        "@edx/frontend-platform": "5.5.4",
         "@edx/paragon": "20.46.2",
         "@fortawesome/fontawesome-svg-core": "1.2.36",
         "@fortawesome/free-brands-svg-icons": "5.15.4",
@@ -2653,9 +2653,9 @@
       }
     },
     "node_modules/@edx/frontend-platform": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-5.4.0.tgz",
-      "integrity": "sha512-cz9yQfHJk1PMQdhxeyIXXiBNqaG9dQZpcBgodmVlLnL/PeN1CuRVjjW98WlKYSrxoZAH5wdgUOr0hKRW3OyBAA==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-5.5.4.tgz",
+      "integrity": "sha512-Yum+oST7XfDwDnDhBnzeR/mjp6O+G0g+5AZtIJ1BdTKQH1z9FObfim/pfoiI9STiYlguVpeWMkzWuca/QMLO/Q==",
       "dependencies": {
         "@cospired/i18n-iso-languages": "4.1.0",
         "@formatjs/intl-pluralrules": "4.3.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@edx/brand": "npm:@edx/brand-openedx@1.2.0",
     "@edx/frontend-component-footer": "12.3.0",
     "@edx/frontend-component-header": "4.7.0",
-    "@edx/frontend-platform": "5.4.0",
+    "@edx/frontend-platform": "5.5.4",
     "@edx/paragon": "20.46.2",
     "@fortawesome/fontawesome-svg-core": "1.2.36",
     "@fortawesome/free-brands-svg-icons": "5.15.4",


### PR DESCRIPTION
# Description
This PR resolves the `PUBLIC_PATH` configuration issue by upgrading frontend-platform from `v5.0.0` to `v5.5.4`.