### PR TITLE
fix: removed extra loader while updating preferences

### DIFF
--- a/src/notification-preferences/NotificationPreferenceRow.jsx
+++ b/src/notification-preferences/NotificationPreferenceRow.jsx
@@ -11,7 +11,7 @@ import {
   selectPreference,
   selectPreferenceNonEditableChannels,
   selectSelectedCourseId,
-  selectNotificationPreferencesStatus,
+  selectUpdatePreferencesStatus,
 } from './data/selectors';
 import { updatePreferenceToggle } from './data/thunks';
 import { LOADING_STATUS } from '../constants';
@@ -22,7 +22,7 @@ const NotificationPreferenceRow = ({ appId, preferenceName }) => {
   const courseId = useSelector(selectSelectedCourseId());
   const preference = useSelector(selectPreference(appId, preferenceName));
   const nonEditable = useSelector(selectPreferenceNonEditableChannels(appId, preferenceName));
-  const preferencesStatus = useSelector(selectNotificationPreferencesStatus());
+  const updatePreferencesStatus = useSelector(selectUpdatePreferencesStatus());
 
   const onToggle = useCallback((event) => {
     const {
@@ -76,7 +76,7 @@ const NotificationPreferenceRow = ({ appId, preferenceName }) => {
               name={channel}
               value={preference[channel]}
               onChange={onToggle}
-              disabled={nonEditable.includes(channel) || preferencesStatus === LOADING_STATUS}
+              disabled={nonEditable.includes(channel) || updatePreferencesStatus === LOADING_STATUS}
             />
           </div>
         ))}

--- a/src/notification-preferences/data/reducers.js
+++ b/src/notification-preferences/data/reducers.js
@@ -15,6 +15,7 @@ export const defaultState = {
   },
   preferences: {
     status: IDLE_STATUS,
+    updatePreferenceStatus: IDLE_STATUS,
     selectedCourse: null,
     preferences: [],
     apps: [],
@@ -70,6 +71,7 @@ const notificationPreferencesReducer = (state = defaultState, action = {}) => {
         preferences: {
           ...state.preferences,
           status: SUCCESS_STATUS,
+          updatePreferenceStatus: SUCCESS_STATUS,
           ...action.payload,
         },
       };
@@ -79,6 +81,7 @@ const notificationPreferencesReducer = (state = defaultState, action = {}) => {
         preferences: {
           ...state.preferences,
           status: FAILURE_STATUS,
+          updatePreferenceStatus: FAILURE_STATUS,
           preferences: [],
           apps: [],
           nonEditable: {},
@@ -102,7 +105,7 @@ const notificationPreferencesReducer = (state = defaultState, action = {}) => {
               ? { ...preference, [notificationChannel]: value }
               : preference
           )),
-          status: LOADING_STATUS,
+          updatePreferenceStatus: LOADING_STATUS,
         },
       };
     case Actions.UPDATE_APP_PREFERENCE:

--- a/src/notification-preferences/data/reducers.test.js
+++ b/src/notification-preferences/data/reducers.test.js
@@ -5,6 +5,7 @@ import {
   FAILURE_STATUS,
   LOADING_STATUS,
   SUCCESS_STATUS,
+  IDLE_STATUS,
 } from '../../constants';
 
 describe('notification-preferences reducer', () => {
@@ -80,15 +81,16 @@ describe('notification-preferences reducer', () => {
     );
     expect(result.preferences).toEqual({
       status: SUCCESS_STATUS,
+      updatePreferenceStatus: SUCCESS_STATUS,
       selectedCourse: null,
       ...preferenceData,
     });
   });
 
   test.each([
-    { action: Actions.FETCHING_PREFERENCES, status: LOADING_STATUS },
-    { action: Actions.FAILED_PREFERENCES, status: FAILURE_STATUS },
-  ])('preferences are empty when api call is %s', ({ action, status }) => {
+    { action: Actions.FETCHING_PREFERENCES, status: LOADING_STATUS, updatePreferenceStatus: IDLE_STATUS },
+    { action: Actions.FAILED_PREFERENCES, status: FAILURE_STATUS, updatePreferenceStatus: FAILURE_STATUS },
+  ])('preferences are empty when api call is %s', ({ action, status, updatePreferenceStatus }) => {
     const result = reducer(
       state,
       { type: action },
@@ -99,6 +101,7 @@ describe('notification-preferences reducer', () => {
       preferences: [],
       apps: [],
       nonEditable: {},
+      updatePreferenceStatus,
     });
   });
 

--- a/src/notification-preferences/data/selectors.js
+++ b/src/notification-preferences/data/selectors.js
@@ -2,6 +2,10 @@ export const selectNotificationPreferencesStatus = () => state => (
   state.notificationPreferences.preferences.status
 );
 
+export const selectUpdatePreferencesStatus = () => state => (
+  state.notificationPreferences.preferences.updatePreferenceStatus
+);
+
 export const selectPreferences = () => state => (
   state.notificationPreferences.preferences?.preferences
 );


### PR DESCRIPTION
[INF-1086](https://2u-internal.atlassian.net/browse/INF-1086)

**Description**
Removed extra loading effect of spinner while updating the notification preferences.

**Screenshots**
**Before**

![Screenshot 2023-10-17 at 1 02 03 PM](https://github.com/openedx/frontend-app-account/assets/72802712/9d203333-2a19-4b67-8155-c71d7733a306)

**After**

![Screenshot 2023-10-17 at 1 04 00 PM](https://github.com/openedx/frontend-app-account/assets/72802712/24466289-ebb7-48bf-bd3b-f39e8167deec)
