### PR TITLE
fix: trim long text in links in the social networks block

### DIFF
--- a/src/account-settings/EditableField.jsx
+++ b/src/account-settings/EditableField.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import classNames from 'classnames';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import {
   Button, Form, StatefulButton,
@@ -155,7 +156,7 @@ const EditableField = (props) => {
                 </Button>
               ) : null}
             </div>
-            <p data-hj-suppress className={isGrayedOut ? 'grayed-out' : null}>{renderValue(value)}</p>
+            <p data-hj-suppress className={classNames('text-truncate', { 'grayed-out': isGrayedOut })}>{renderValue(value)}</p>
             <p className="small text-muted mt-n2">{renderConfirmationMessage() || helpText}</p>
           </div>
         ),


### PR DESCRIPTION
#### Description
This pull request contains minor fixes for when a user pastes a very long link into the social media links field.
In this case, the links break the page and add horizontal scrolling.

#### Screenshot before
<img width="1020" alt="image" src="https://github.com/openedx/frontend-app-account/assets/17108583/2e2add1e-1112-4ccc-9cf3-78ba73f199d6">

#### Screenshot after
<img width="1021" alt="image" src="https://github.com/openedx/frontend-app-account/assets/17108583/1673f055-e31e-4369-94b2-372bc5bb3d7c">

#### Related Pull Requests
PR to the open-release/palm.master branch: https://github.com/openedx/frontend-app-account/pull/915
