### PR TITLE
fix: error when trying to save 'other education'

### DIFF
--- a/src/account-settings/AccountSettingsPage.messages.jsx
+++ b/src/account-settings/AccountSettingsPage.messages.jsx
@@ -411,8 +411,8 @@ const messages = defineMessages({
     defaultMessage: 'No formal education',
     description: 'Selected by the user to describe their education.',
   },
-  'account.settings.field.education.levels.o': {
-    id: 'account.settings.field.education.levels.o',
+  'account.settings.field.education.levels.other': {
+    id: 'account.settings.field.education.levels.other',
     defaultMessage: 'Other education',
     description: 'Selected by the user if they have a type of education not described by the other choices.',
   },

--- a/src/account-settings/data/constants.js
+++ b/src/account-settings/data/constants.js
@@ -25,7 +25,7 @@ export const EDUCATION_LEVELS = [
   'jhs',
   'el',
   'none',
-  'o',
+  'other',
 ];
 
 export const GENDER_OPTIONS = [


### PR DESCRIPTION
When user selects "Other Education" and clicks save - error occurs.

It's caused by the wrong API call payload value `'o'`
Fix: use the `'other'` payload value instead (the valid one).

Port from: [palm.master](https://github.com/openedx/frontend-app-account/pull/881)
Related: [open-release/quince.master](https://github.com/openedx/frontend-app-account/pull/926)
