### PR TITLE
fix: app level toggle is now disabled during api call

### DIFF
--- a/src/notification-preferences/NotificationPreferenceApp.jsx
+++ b/src/notification-preferences/NotificationPreferenceApp.jsx
@@ -9,9 +9,11 @@ import {
   selectPreferenceAppToggleValue,
   selectPreferencesOfApp,
   selectSelectedCourseId,
+  selectUpdatePreferencesStatus,
 } from './data/selectors';
 import NotificationPreferenceRow from './NotificationPreferenceRow';
 import { updateAppPreferenceToggle } from './data/thunks';
+import { LOADING_STATUS } from '../constants';
 
 const NotificationPreferenceApp = ({ appId }) => {
   const dispatch = useDispatch();
@@ -19,6 +21,7 @@ const NotificationPreferenceApp = ({ appId }) => {
   const courseId = useSelector(selectSelectedCourseId());
   const appPreferences = useSelector(selectPreferencesOfApp(appId));
   const appToggle = useSelector(selectPreferenceAppToggleValue(appId));
+  const updatePreferencesStatus = useSelector(selectUpdatePreferencesStatus());
 
   const preferences = useMemo(() => (
     appPreferences.map(preference => (
@@ -49,6 +52,7 @@ const NotificationPreferenceApp = ({ appId }) => {
               name={appId}
               value={appToggle}
               onChange={onChangeAppSettings}
+              disabled={updatePreferencesStatus === LOADING_STATUS}
             />
           </span>
         </div>


### PR DESCRIPTION
[INF-1164](https://2u-internal.atlassian.net/browse/INF-1164)

**Description**
The toggle for App Level Preferences is disabled during an ongoing API call.

**Screenshot**

https://www.loom.com/share/7c722f2f0b034458b2232b60f5183d45?sid=c37aa2a2-f811-4fb3-b069-131978ef3c7a