### PR TITLE
fix: disable app level toggle during api call

### DIFF
--- a/src/notification-preferences/data/reducers.js
+++ b/src/notification-preferences/data/reducers.js
@@ -118,6 +118,7 @@ const notificationPreferencesReducer = (state = defaultState, action = {}) => {
               ? { ...app, enabled: value }
               : app
           )),
+          updatePreferenceStatus: LOADING_STATUS,
         },
       };
     default:


### PR DESCRIPTION
**Description**

**Issue:** When frequently enabling/disabling the App level toggle, I observed some flickering on the screen.
**Fixed:** The App level toggle will now be disabled during API calls.

**Screenshots**
**Before**
https://www.loom.com/share/c407050bfffd423396464a214de83844?sid=97f3e7e7-1865-4062-bdf4-e1b1ac844f2d

**After**
https://www.loom.com/share/ba5fc124beab4746b478e0eb43dfa578?sid=4e1c3d5f-dc4e-4824-8ef2-2a33d98c51f0