### PR TITLE
feat: Restore jump nav and content width

### DIFF
--- a/src/account-settings/AccountSettingsPage.jsx
+++ b/src/account-settings/AccountSettingsPage.jsx
@@ -859,10 +859,10 @@ class AccountSettingsPage extends React.Component {
         </h1>
         <div>
           <div className="row">
-            <div className="col-md-2">
+            <div className="col-md-3">
               <JumpNav />
             </div>
-            <div className="col-md-10">
+            <div className="col-md-9">
               {loading ? this.renderLoading() : null}
               {loaded ? this.renderContent() : null}
               {loadingError ? this.renderError() : null}

--- a/src/account-settings/JumpNav.jsx
+++ b/src/account-settings/JumpNav.jsx
@@ -13,7 +13,7 @@ const JumpNav = ({
   const stickToTop = useWindowSize().width > breakpoints.small.minWidth;
 
   return (
-    <div className={classNames('jump-nav px-2.25', { 'jump-nav-sm position-sticky pt-3': stickToTop })}>
+    <div className={classNames('jump-nav', { 'jump-nav-sm position-sticky pt-3': stickToTop })}>
       <Scrollspy
         items={[
           'basic-information',


### PR DESCRIPTION
Our proposal is to modify the width values of jump-nav and content to their state prior to this pull request - https://github.com/openedx/frontend-app-account/pull/784. In this pull request, the width of the jump nav was reduced, and the width of the content was increased. This results in the jump nav appearing very narrow on themes with a maximum container width. Even the phrase "Account Information" does not fit into a single line
![Снимок экрана 2024-02-08 в 14 04 57](https://github.com/openedx/frontend-app-account/assets/19806032/7133c71b-4f23-45c4-9843-f8ec5033208d)

After this small fix we'll restore previous state of the columns width, like in Palm
![Снимок экрана 2024-02-08 в 14 17 59](https://github.com/openedx/frontend-app-account/assets/19806032/e07e4967-a3f9-41f0-8a13-c689a8820f97)