### PR TITLE
feat: Restore jump nav and content width [backport from master]

### DIFF
--- a/src/account-settings/AccountSettingsPage.jsx
+++ b/src/account-settings/AccountSettingsPage.jsx
@@ -814,12 +814,12 @@ class AccountSettingsPage extends React.Component {
         </h1>
         <div>
           <div className="row">
-            <div className="col-md-2">
+            <div className="col-md-3">
               <JumpNav
                 displayDemographicsLink={this.props.formValues.shouldDisplayDemographicsSection}
               />
             </div>
-            <div className="col-md-10">
+            <div className="col-md-9">
               {loading ? this.renderLoading() : null}
               {loaded ? this.renderContent() : null}
               {loadingError ? this.renderError() : null}

--- a/src/account-settings/JumpNav.jsx
+++ b/src/account-settings/JumpNav.jsx
@@ -20,7 +20,7 @@ const JumpNav = ({
   const showPreferences = useSelector(selectShowPreferences());
 
   return (
-    <div className={classNames('jump-nav px-2.25', { 'jump-nav-sm position-sticky pt-3': stickToTop })}>
+    <div className={classNames('jump-nav', { 'jump-nav-sm position-sticky pt-3': stickToTop })}>
       <Scrollspy
         items={[
           'basic-information',

--- a/src/account-settings/test/__snapshots__/JumpNav.test.jsx.snap
+++ b/src/account-settings/test/__snapshots__/JumpNav.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`JumpNav should not render Optional Information or delete account link 1`] = `
 <div
-  className="jump-nav px-2.25 jump-nav-sm position-sticky pt-3"
+  className="jump-nav jump-nav-sm position-sticky pt-3"
 >
   <ul
     className="list-unstyled"
@@ -79,7 +79,7 @@ exports[`JumpNav should not render Optional Information or delete account link 1
 
 exports[`JumpNav should render Optional Information and delete account link 1`] = `
 <div
-  className="jump-nav px-2.25 jump-nav-sm position-sticky pt-3"
+  className="jump-nav jump-nav-sm position-sticky pt-3"
 >
   <ul
     className="list-unstyled"


### PR DESCRIPTION
This is backport from master https://github.com/openedx/frontend-app-account/pull/994

Our proposal is to modify the width values of jump-nav and content to their state prior to this pull request - https://github.com/openedx/frontend-app-account/pull/784. In this pull request, the width of the jump nav was reduced, and the width of the content was increased. This results in the jump nav appearing very narrow on themes with a maximum container width. Even the phrase "Account Information" does not fit into a single line
![Снимок экрана 2024-02-08 в 14 04 57](https://github.com/openedx/frontend-app-account/assets/19806032/7133c71b-4f23-45c4-9843-f8ec5033208d)
After this small fix we'll restore previous state of the columns width, like in Palm
![Снимок экрана 2024-02-08 в 14 17 59](https://github.com/openedx/frontend-app-account/assets/19806032/e07e4967-a3f9-41f0-8a13-c689a8820f97)