### PR TITLE
fix: long email field on account page

### DIFF
--- a/src/account-settings/EmailField.jsx
+++ b/src/account-settings/EmailField.jsx
@@ -162,7 +162,7 @@ const EmailField = (props) => {
                 </Button>
               ) : null}
             </div>
-            <p data-hj-suppress>{renderValue()}</p>
+            <p data-hj-suppress className="text-truncate">{renderValue()}</p>
             {renderConfirmationMessage() || <p className="small text-muted mt-n2">{helpText}</p>}
           </div>
         ),

--- a/src/account-settings/EmailField.jsx
+++ b/src/account-settings/EmailField.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { injectIntl, intlShape, FormattedMessage } from '@edx/frontend-platform/i18n';
 import {
-  Button, StatefulButton, Form,
+  Button, StatefulButton, Form, Tooltip, OverlayTrigger,
 } from '@openedx/paragon';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faExclamationTriangle, faPencilAlt } from '@fortawesome/free-solid-svg-icons';
@@ -162,7 +162,16 @@ const EmailField = (props) => {
                 </Button>
               ) : null}
             </div>
-            <p data-hj-suppress className="text-truncate">{renderValue()}</p>
+            <OverlayTrigger
+              placement="top"
+              overlay={(
+                <Tooltip id={`tooltip-${name}`} variant="light" className="d-sm-none">
+                  {renderValue()}
+                </Tooltip>
+              )}
+            >
+              <p data-hj-suppress className="text-truncate">{renderValue()}</p>
+            </OverlayTrigger>
             {renderConfirmationMessage() || <p className="small text-muted mt-n2">{helpText}</p>}
           </div>
         ),

--- a/src/account-settings/_style.scss
+++ b/src/account-settings/_style.scss
@@ -29,7 +29,6 @@
     }
   }
 
-
   .custom-switch {
     padding: 0;
     max-width: 500px;
@@ -43,4 +42,9 @@
     opacity: 0.6; /* Real browsers */
     filter: alpha(opacity = 60); /* MSIE */
   }
+}
+
+#tooltip-email .small {
+  display: block;
+  margin: 0 !important;
 }


### PR DESCRIPTION
Similar PR is opened to the open-release/quince branch:
https://github.com/openedx/frontend-app-account/pull/1025

Fix for the long email field to prevent page break for the mobile view:

If user has a long type email it will be overlap from content of page:
<img width="504" alt="1" src="https://github.com/openedx/frontend-app-account/assets/25877054/446e285c-2d19-4670-a4bd-85b15bbfc107">
<img width="561" alt="11" src="https://github.com/openedx/frontend-app-account/assets/25877054/39fefb87-bf25-4f98-8f5e-66aa330bc186">


After fix:
<img width="536" alt="2" src="https://github.com/openedx/frontend-app-account/assets/25877054/a9d02fb6-8b1e-4e60-91ec-57df03af042c">
<img width="546" alt="22" src="https://github.com/openedx/frontend-app-account/assets/25877054/02ab1971-4ef7-4a31-9e46-cc2cad46c9c1">

