### PR TITLE
fix: long email field on account page

### DIFF
--- a/src/account-settings/EmailField.jsx
+++ b/src/account-settings/EmailField.jsx
@@ -162,7 +162,7 @@ const EmailField = (props) => {
                 </Button>
               ) : null}
             </div>
-            <p data-hj-suppress>{renderValue()}</p>
+            <p data-hj-suppress className="text-truncate">{renderValue()}</p>
             {renderConfirmationMessage() || <p className="small text-muted mt-n2">{helpText}</p>}
           </div>
         ),


### PR DESCRIPTION
Similar PR is opened to the master branch:
https://github.com/openedx/frontend-app-account/pull/1024

Fix for the long email field to prevent page break for the mobile view:

If user has a long type email it will be overlap from content of page:
<img width="504" alt="1" src="https://github.com/openedx/frontend-app-account/assets/25877054/446e285c-2d19-4670-a4bd-85b15bbfc107">
<img width="561" alt="11" src="https://github.com/openedx/frontend-app-account/assets/25877054/39fefb87-bf25-4f98-8f5e-66aa330bc186">


After fix:
<img width="536" alt="2" src="https://github.com/openedx/frontend-app-account/assets/25877054/a9d02fb6-8b1e-4e60-91ec-57df03af042c">
<img width="546" alt="22" src="https://github.com/openedx/frontend-app-account/assets/25877054/02ab1971-4ef7-4a31-9e46-cc2cad46c9c1">

