### PR TITLE
fix: core notification is now not visible under updates

### DIFF
--- a/src/notification-preferences/NotificationPreferenceColumn.jsx
+++ b/src/notification-preferences/NotificationPreferenceColumn.jsx
@@ -52,6 +52,7 @@ const NotificationPreferenceColumn = ({ appId, channel, appPreference }) => {
   }, [appId]);
 
   const renderPreference = (preference) => (
+    (preference.coreNotificationTypes.length > 0 || preference.id !== 'core') && (
     <div
       key={`${preference.id}-${channel}`}
       id={`${preference.id}-${channel}`}
@@ -80,6 +81,7 @@ const NotificationPreferenceColumn = ({ appId, channel, appPreference }) => {
       />
       )}
     </div>
+    )
   );
 
   return (

--- a/src/notification-preferences/NotificationPreferenceColumn.jsx
+++ b/src/notification-preferences/NotificationPreferenceColumn.jsx
@@ -52,7 +52,7 @@ const NotificationPreferenceColumn = ({ appId, channel, appPreference }) => {
   }, [appId]);
 
   const renderPreference = (preference) => (
-    (preference.coreNotificationTypes.length > 0 || preference.id !== 'core') && (
+    (preference?.coreNotificationTypes?.length > 0 || preference.id !== 'core') && (
     <div
       key={`${preference.id}-${channel}`}
       id={`${preference.id}-${channel}`}

--- a/src/notification-preferences/NotificationPreferences.test.jsx
+++ b/src/notification-preferences/NotificationPreferences.test.jsx
@@ -36,6 +36,7 @@ const defaultPreferences = {
       web: true,
       push: true,
       email: true,
+      coreNotificationTypes: ['new_comment'],
     },
     {
       id: 'newComment',
@@ -43,6 +44,7 @@ const defaultPreferences = {
       web: false,
       push: false,
       email: false,
+      coreNotificationTypes: [],
     },
     {
       id: 'newAssignment',
@@ -50,6 +52,7 @@ const defaultPreferences = {
       web: false,
       push: false,
       email: false,
+      coreNotificationTypes: [],
     },
     {
       id: 'newGrade',
@@ -57,6 +60,7 @@ const defaultPreferences = {
       web: false,
       push: false,
       email: false,
+      coreNotificationTypes: [],
     },
   ],
   nonEditable: {
@@ -70,9 +74,15 @@ const defaultPreferences = {
 
 const updateChannelPreferences = (toggleVal = false) => ({
   preferences: [
-    { id: 'core', appId: 'discussion', web: true },
-    { id: 'newComment', appId: 'discussion', web: toggleVal },
-    { id: 'newAssignment', appId: 'coursework', web: toggleVal },
+    {
+      id: 'core', appId: 'discussion', web: true, coreNotificationTypes: ['new_comment'],
+    },
+    {
+      id: 'newComment', appId: 'discussion', web: toggleVal, coreNotificationTypes: [],
+    },
+    {
+      id: 'newAssignment', appId: 'coursework', web: toggleVal, coreNotificationTypes: [],
+    },
   ],
 });
 

--- a/src/notification-preferences/NotificationTypes.jsx
+++ b/src/notification-preferences/NotificationTypes.jsx
@@ -21,7 +21,7 @@ const NotificationTypes = ({ appId }) => {
     <div className="d-flex flex-column mr-auto px-0">
       {!mobileView && <span className="mb-3 header-label">{intl.formatMessage(messages.typeLabel)}</span>}
       {preferences.map(preference => (
-        (preference.coreNotificationTypes.length > 0 || preference.id !== 'core') && (
+        (preference?.coreNotificationTypes?.length > 0 || preference.id !== 'core') && (
         <>
           <div
             key={preference.id}

--- a/src/notification-preferences/NotificationTypes.jsx
+++ b/src/notification-preferences/NotificationTypes.jsx
@@ -21,6 +21,7 @@ const NotificationTypes = ({ appId }) => {
     <div className="d-flex flex-column mr-auto px-0">
       {!mobileView && <span className="mb-3 header-label">{intl.formatMessage(messages.typeLabel)}</span>}
       {preferences.map(preference => (
+        (preference.coreNotificationTypes.length > 0 || preference.id !== 'core') && (
         <>
           <div
             key={preference.id}
@@ -53,6 +54,8 @@ const NotificationTypes = ({ appId }) => {
           </div>
           )}
         </>
+        )
+
       ))}
     </div>
   );

--- a/src/notification-preferences/data/thunks.js
+++ b/src/notification-preferences/data/thunks.js
@@ -60,6 +60,7 @@ const normalizePreferences = (responseData) => {
         email: preferences[appId].notificationTypes[preferenceId].email,
         info: preferences[appId].notificationTypes[preferenceId].info || '',
         emailCadence: preferences[appId].notificationTypes[preferenceId].emailCadence || EMAIL_CADENCE.DAILY,
+        coreNotificationTypes: preferences[appId].coreNotificationTypes || [],
       }
     ));
     nonEditable[appId] = preferences[appId].nonEditable;


### PR DESCRIPTION
[INF-1283](https://2u-internal.atlassian.net/browse/INF-1283)

**Description**
We've removed core notifications from the frontend, as the Updates app currently doesn't include any core notifications. We've updated the logic on the frontend to verify if there are any core notifications available for an app. If not, we're no longer displaying core preferences for that notification app.
