### PR TITLE
fix: use `frontend-slot-footer` that supports all footer versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@fortawesome/free-solid-svg-icons": "5.15.4",
         "@fortawesome/react-fontawesome": "0.2.0",
         "@openedx/frontend-plugin-framework": "^1.1.2",
-        "@openedx/frontend-slot-footer": "^1.0.0",
+        "@openedx/frontend-slot-footer": "^1.0.2",
         "@openedx/paragon": "22.0.0",
         "@tensorflow-models/blazeface": "0.0.7",
         "@tensorflow/tfjs-converter": "3.21.0",
@@ -3662,17 +3662,15 @@
       }
     },
     "node_modules/@openedx/frontend-slot-footer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-slot-footer/-/frontend-slot-footer-1.0.0.tgz",
-      "integrity": "sha512-9fPyT/vuvqtbkgZ0c9YWp3rcweCA8KLY+wDZy6h5Z0D8P+jNr9X8cXR529RzVkLJZfsMFKmQa7LzpdIwVJ/tyw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-slot-footer/-/frontend-slot-footer-1.0.2.tgz",
+      "integrity": "sha512-Wmx/Das4wr3jYQ1/wk9ctYcM9ztfpY5fm6d5UKFSnKK1DbUbjliaPC3mdGR4wVRnH4MAf1OnNGZ8oj/bTDPGHg==",
       "dependencies": {
         "@openedx/frontend-plugin-framework": "^1.1.2"
       },
       "peerDependencies": {
-        "@edx/frontend-component-footer": "^14.0.0",
-        "core-js": "3.37.0",
-        "react": "^17.0.0",
-        "regenerator-runtime": "0.14.1"
+        "@edx/frontend-component-footer": "*",
+        "react": "^17.0.0"
       }
     },
     "node_modules/@openedx/paragon": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@fortawesome/free-solid-svg-icons": "5.15.4",
     "@fortawesome/react-fontawesome": "0.2.0",
     "@openedx/frontend-plugin-framework": "^1.1.2",
-    "@openedx/frontend-slot-footer": "^1.0.0",
+    "@openedx/frontend-slot-footer": "^1.0.2",
     "@openedx/paragon": "22.0.0",
     "@tensorflow-models/blazeface": "0.0.7",
     "@tensorflow/tfjs-converter": "3.21.0",


### PR DESCRIPTION
The previous version of `frontend-slot-footer` had a peer dependency of `^14.0.0`, which caused problems for some methods of installing forked footers. This updates to a version of `frontend-slot-footer` that allows for *any* version of `frontend-component-footer` in the peer dependency.