### PR TITLE
fix: disabled email cadence dropdown while api is pending

### DIFF
--- a/src/notification-preferences/EmailCadences.jsx
+++ b/src/notification-preferences/EmailCadences.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 
 import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
 
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { ExpandLess, ExpandMore } from '@openedx/paragon/icons';
@@ -10,6 +11,8 @@ import {
 
 import messages from './messages';
 import EMAIL_CADENCE from './data/constants';
+import { selectUpdatePreferencesStatus } from './data/selectors';
+import { LOADING_STATUS } from '../constants';
 
 const EmailCadences = ({
   email, onToggle, emailCadence, notificationType,
@@ -17,6 +20,7 @@ const EmailCadences = ({
   const intl = useIntl();
   const [isOpen, open, close] = useToggle(false);
   const [target, setTarget] = useState(null);
+  const updatePreferencesStatus = useSelector(selectUpdatePreferencesStatus());
 
   return (
     <>
@@ -24,7 +28,7 @@ const EmailCadences = ({
         ref={setTarget}
         variant="outline-primary"
         onClick={open}
-        disabled={!email}
+        disabled={!email || updatePreferencesStatus === LOADING_STATUS}
         size="sm"
         iconAfter={isOpen ? ExpandLess : ExpandMore}
         className="border-light-300 justify-content-between ml-3.5 cadence-button"


### PR DESCRIPTION
[INF-1389](https://2u-internal.atlassian.net/browse/INF-1389)

**Description**
In notification preference view, when a patch call is initiated to updated, all of the toggles and dropdowns must be disabled. 

**Solution**
Disabled dropdowns while api response is in pending state