### PR TITLE
temp: removing immediately from email preferences

### DIFF
--- a/src/notification-preferences/data/constants.js
+++ b/src/notification-preferences/data/constants.js
@@ -1,7 +1,6 @@
 const EMAIL_CADENCE = {
   DAILY: 'Daily',
   WEEKLY: 'Weekly',
-  IMMEDIATELY: 'Immediately',
   NEVER: 'Never',
 };
 


### PR DESCRIPTION
Removing `Immediately` from email preference dropdown. It will be added after implementation.
 