### PR TITLE
fix: Updated copy change on Name Change modal

### DIFF
--- a/src/account-settings/AccountSettingsPage.messages.jsx
+++ b/src/account-settings/AccountSettingsPage.messages.jsx
@@ -141,11 +141,6 @@ const messages = defineMessages({
     defaultMessage: 'Once your proctored exam passes review, this name will appear on your certificate and public-facing records. Verified Name cannot be changed at this time.',
     description: 'Help text for the account settings verified name field when a verified name has been submitted through proctoring and will appear on certificates.',
   },
-  'account.settings.field.name.verified.verification.alert': {
-    id: 'account.settings.field.name.verified.verification.help',
-    defaultMessage: 'Enter your name as it appears on your identification card.',
-    description: 'Form label instructing the user to enter the name on their ID.',
-  },
   'account.settings.field.full.name.help.text.submitted': {
     id: 'account.settings.field.full.name.help.text.submitted',
     defaultMessage: 'Verification has been submitted. This usually takes 48 hours or less. Full name cannot be changed at this time.',

--- a/src/account-settings/AccountSettingsPage.messages.jsx
+++ b/src/account-settings/AccountSettingsPage.messages.jsx
@@ -143,7 +143,7 @@ const messages = defineMessages({
   },
   'account.settings.field.name.verified.verification.alert': {
     id: 'account.settings.field.name.verified.verification.help',
-    defaultMessage: 'Enter your name as it appears on your unexpired student, work, or government-issued identification card.',
+    defaultMessage: 'Enter your name as it appears on your identification card.',
     description: 'Form label instructing the user to enter the name on their ID.',
   },
   'account.settings.field.full.name.help.text.submitted': {

--- a/src/account-settings/name-change/messages.js
+++ b/src/account-settings/name-change/messages.js
@@ -23,7 +23,7 @@ const messages = defineMessages({
   },
   'account.settings.name.change.id.name.label': {
     id: 'account.settings.name.change.id.name.label',
-    defaultMessage: 'Enter your name as it appears on your unexpired student, work, or government-issued identification card.',
+    defaultMessage: 'Enter your name as it appears on your identification card.',
     description: 'Form label instructing the user to enter the name on their ID.',
   },
   'account.settings.name.change.id.name.placeholder': {


### PR DESCRIPTION
### Description

Just a copy change on the Name Change modal. This is part of the New IDV vendor work https://github.com/openedx/platform-roadmap/issues/367.

Old copy:
> Enter your name as it appears on your unexpired student, work, or government-issued identification card.

New copy:
> Enter your name as it appears on your identification card.

#### How Has This Been Tested?

Tested locally.

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.