### PR TITLE
import FooterSlot from frontend-slot-footer package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@fortawesome/free-solid-svg-icons": "5.15.4",
         "@fortawesome/react-fontawesome": "0.2.0",
         "@openedx/frontend-plugin-framework": "^1.1.2",
-        "@openedx/frontend-slot-footer": "^1.0.0",
+        "@openedx/frontend-slot-footer": "^1.0.2",
         "@openedx/paragon": "22.0.0",
         "@tensorflow-models/blazeface": "0.0.7",
         "@tensorflow/tfjs-converter": "3.21.0",
@@ -3668,17 +3668,15 @@
       }
     },
     "node_modules/@openedx/frontend-slot-footer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-slot-footer/-/frontend-slot-footer-1.0.0.tgz",
-      "integrity": "sha512-9fPyT/vuvqtbkgZ0c9YWp3rcweCA8KLY+wDZy6h5Z0D8P+jNr9X8cXR529RzVkLJZfsMFKmQa7LzpdIwVJ/tyw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-slot-footer/-/frontend-slot-footer-1.0.2.tgz",
+      "integrity": "sha512-Wmx/Das4wr3jYQ1/wk9ctYcM9ztfpY5fm6d5UKFSnKK1DbUbjliaPC3mdGR4wVRnH4MAf1OnNGZ8oj/bTDPGHg==",
       "dependencies": {
         "@openedx/frontend-plugin-framework": "^1.1.2"
       },
       "peerDependencies": {
-        "@edx/frontend-component-footer": "^14.0.0",
-        "core-js": "3.37.0",
-        "react": "^17.0.0",
-        "regenerator-runtime": "0.14.1"
+        "@edx/frontend-component-footer": "*",
+        "react": "^17.0.0"
       }
     },
     "node_modules/@openedx/paragon": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
-        "@edx/frontend-component-footer": "^13.2.0",
-        "@edx/frontend-component-header": "5.3.0",
+        "@edx/frontend-component-header": "5.3.1",
         "@edx/frontend-platform": "8.0.1",
         "@edx/openedx-atlas": "^0.6.0",
         "@fortawesome/fontawesome-svg-core": "1.2.36",
@@ -20,6 +19,7 @@
         "@fortawesome/free-solid-svg-icons": "5.15.4",
         "@fortawesome/react-fontawesome": "0.2.0",
         "@openedx/frontend-plugin-framework": "^1.1.2",
+        "@openedx/frontend-slot-footer": "^1.0.0",
         "@openedx/paragon": "22.0.0",
         "@tensorflow-models/blazeface": "0.0.7",
         "@tensorflow/tfjs-converter": "3.21.0",
@@ -2107,9 +2107,10 @@
       }
     },
     "node_modules/@edx/frontend-component-footer": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-component-footer/-/frontend-component-footer-13.2.0.tgz",
-      "integrity": "sha512-oXcNSZ+1o1TFIolBmd3mdQsDQ0fzJZMK5hNvEIwWbyLNX6977t7QjyihocYlLY+0LMl3LmqdSJpSuvNzBrvCyA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-component-footer/-/frontend-component-footer-14.0.0.tgz",
+      "integrity": "sha512-3Riz6ippBnPz1oq6gZgFBx27bJkNL+rwwKrv0uCuHV/5MscS1aYeKx1ZAMuUsxkKcGX6uhyU6PwM6agvnhKfNQ==",
+      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "6.5.2",
         "@fortawesome/free-brands-svg-icons": "6.5.2",
@@ -2139,6 +2140,7 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.2.tgz",
       "integrity": "sha512-gBxPg3aVO6J0kpfHNILc+NMhXnqHumFxOmjYCFfOiLZfwhnnfhtsdA2hfJlDnj+8PjAs6kKQPenOTKj3Rf7zHw==",
       "hasInstallScript": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -2148,6 +2150,7 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.5.2.tgz",
       "integrity": "sha512-5CdaCBGl8Rh9ohNdxeeTMxIj8oc3KNBgIeLMvJosBMdslK/UnEB8rzyDRrbKdL1kDweqBPo4GT9wvnakHWucZw==",
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.5.2"
       },
@@ -2160,6 +2163,7 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.5.2.tgz",
       "integrity": "sha512-zi5FNYdmKLnEc0jc0uuHH17kz/hfYTg4Uei0wMGzcoCL/4d3WM3u1VMc0iGGa31HuhV5i7ZK8ZlTCQrHqRHSGQ==",
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.5.2"
       },
@@ -2172,6 +2176,7 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.5.2.tgz",
       "integrity": "sha512-iabw/f5f8Uy2nTRtJ13XZTS1O5+t+anvlamJ3zJGLEVE2pKsAWhPv2lq01uQlfgCX7VaveT3EVs515cCN9jRbw==",
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.5.2"
       },
@@ -2184,6 +2189,7 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.5.2.tgz",
       "integrity": "sha512-QWFZYXFE7O1Gr1dTIp+D6UcFUF0qElOnZptpi7PBUMylJh+vFmIedVe1Ir6RM1t2tEQLLSV1k7bR4o92M+uqlw==",
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.5.2"
       },
@@ -3659,6 +3665,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/@openedx/frontend-slot-footer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-slot-footer/-/frontend-slot-footer-1.0.0.tgz",
+      "integrity": "sha512-9fPyT/vuvqtbkgZ0c9YWp3rcweCA8KLY+wDZy6h5Z0D8P+jNr9X8cXR529RzVkLJZfsMFKmQa7LzpdIwVJ/tyw==",
+      "dependencies": {
+        "@openedx/frontend-plugin-framework": "^1.1.2"
+      },
+      "peerDependencies": {
+        "@edx/frontend-component-footer": "^14.0.0",
+        "core-js": "3.37.0",
+        "react": "^17.0.0",
+        "regenerator-runtime": "0.14.1"
       }
     },
     "node_modules/@openedx/paragon": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@fortawesome/free-solid-svg-icons": "5.15.4",
     "@fortawesome/react-fontawesome": "0.2.0",
     "@openedx/frontend-plugin-framework": "^1.1.2",
-    "@openedx/frontend-slot-footer": "^1.0.0",
+    "@openedx/frontend-slot-footer": "^1.0.2",
     "@openedx/paragon": "22.0.0",
     "@tensorflow-models/blazeface": "0.0.7",
     "@tensorflow/tfjs-converter": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
   ],
   "dependencies": {
     "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
-    "@edx/frontend-component-footer": "^13.2.0",
-    "@edx/frontend-component-header": "5.3.0",
+    "@edx/frontend-component-header": "5.3.1",
     "@edx/frontend-platform": "8.0.1",
     "@edx/openedx-atlas": "^0.6.0",
     "@fortawesome/fontawesome-svg-core": "1.2.36",
@@ -38,6 +37,7 @@
     "@fortawesome/free-solid-svg-icons": "5.15.4",
     "@fortawesome/react-fontawesome": "0.2.0",
     "@openedx/frontend-plugin-framework": "^1.1.2",
+    "@openedx/frontend-slot-footer": "^1.0.0",
     "@openedx/paragon": "22.0.0",
     "@tensorflow-models/blazeface": "0.0.7",
     "@tensorflow/tfjs-converter": "3.21.0",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -11,7 +11,7 @@ import ReactDOM from 'react-dom';
 import { Route, Routes, Outlet } from 'react-router-dom';
 
 import Header from '@edx/frontend-component-header';
-import { FooterSlot } from '@edx/frontend-component-footer';
+import FooterSlot from '@openedx/frontend-slot-footer';
 
 import configureStore from './data/configureStore';
 import AccountSettingsPage, { NotFoundPage } from './account-settings';

--- a/src/plugin-slots/FooterSlot/README.md
+++ b/src/plugin-slots/FooterSlot/README.md
@@ -18,7 +18,7 @@ with a simple custom footer
 
 ![Screenshot of Custom Footer](./images/custom_footer.png)
 
-```js
+```jsx
 import { DIRECT_PLUGIN, PLUGIN_OPERATIONS } from '@openedx/frontend-plugin-framework';
 
 const config = {


### PR DESCRIPTION
Backport PR of #1048 and #1050 

Issue:
Account MFE generates an error when custom footer is installed and Other MFEs are working fine with the same footer. The problem is that Account MFE is not importing the footer from "fronted-slot-footer" package while other MFEs are doing so. This is resolved in `master` branch of Account MFE but need to backport in `open-release/redwood.master`.