### PR TITLE
feat: added country disabling feature

### DIFF
--- a/src/account-settings/AccountSettingsPage.jsx
+++ b/src/account-settings/AccountSettingsPage.jsx
@@ -120,7 +120,15 @@ class AccountSettingsPage extends React.Component {
     countryOptions: [{
       value: '',
       label: this.props.intl.formatMessage(messages['account.settings.field.country.options.empty']),
-    }].concat(getCountryList(locale).map(({ code, name }) => ({ value: code, label: name }))),
+    }].concat(
+      this.removeDisabledCountries(
+        getCountryList(locale).map(({ code, name }) => ({
+          value: code,
+          label: name,
+          disabled: this.isDisabledCountry(code),
+        })),
+      ),
+    ),
     stateOptions: [{
       value: '',
       label: this.props.intl.formatMessage(messages['account.settings.field.state.options.empty']),
@@ -147,11 +155,30 @@ class AccountSettingsPage extends React.Component {
     })),
   }));
 
+  removeDisabledCountries = (countryList) => {
+    const { disabledCountries, committedValues } = this.props;
+
+    if (!disabledCountries.length) {
+      return countryList;
+    }
+
+    return countryList.filter(({ value }) => {
+      const isDisabled = this.isDisabledCountry(value);
+      const isUserCountry = value === committedValues.country;
+
+      return !isDisabled || isUserCountry;
+    });
+  };
+
   handleEditableFieldChange = (name, value) => {
     this.props.updateDraft(name, value);
   };
 
   handleSubmit = (formId, values) => {
+    if (formId === 'country' && this.isDisabledCountry(values)) {
+      return;
+    }
+
     const { formValues } = this.props;
     let extendedProfileObject = {};
 
@@ -191,6 +218,11 @@ class AccountSettingsPage extends React.Component {
     } else {
       this.props.saveSettings(formId, values);
     }
+  };
+
+  isDisabledCountry = (country) => {
+    const { disabledCountries } = this.props;
+    return disabledCountries.includes(country);
   };
 
   isEditable(fieldName) {
@@ -476,7 +508,8 @@ class AccountSettingsPage extends React.Component {
     } = this.getLocalizedOptions(this.context.locale, this.props.formValues.country);
 
     // Show State field only if the country is US (could include Canada later)
-    const showState = this.props.formValues.country === COUNTRY_WITH_STATES;
+    const { country } = this.props.formValues;
+    const showState = country === COUNTRY_WITH_STATES && !this.isDisabledCountry(country);
     const { verifiedName } = this.props;
 
     const hasWorkExperience = !!this.props.formValues?.extended_profile?.find(field => field.field_name === 'work_experience');
@@ -880,6 +913,7 @@ AccountSettingsPage.propTypes = {
     name: PropTypes.string,
     useVerifiedNameForCerts: PropTypes.bool,
     verified_name: PropTypes.string,
+    country: PropTypes.string,
   }),
   drafts: PropTypes.shape({}),
   formErrors: PropTypes.shape({
@@ -938,6 +972,7 @@ AccountSettingsPage.propTypes = {
   ),
   navigate: PropTypes.func.isRequired,
   location: PropTypes.string.isRequired,
+  disabledCountries: PropTypes.arrayOf(PropTypes.string),
 };
 
 AccountSettingsPage.defaultProps = {
@@ -947,6 +982,7 @@ AccountSettingsPage.defaultProps = {
   committedValues: {
     useVerifiedNameForCerts: false,
     verified_name: null,
+    country: '',
   },
   drafts: {},
   formErrors: {},
@@ -963,6 +999,7 @@ AccountSettingsPage.defaultProps = {
   verifiedName: null,
   mostRecentVerifiedName: {},
   verifiedNameHistory: [],
+  disabledCountries: [],
 };
 
 export default withLocation(withNavigate(connect(accountSettingsPageSelector, {

--- a/src/account-settings/AccountSettingsPage.jsx
+++ b/src/account-settings/AccountSettingsPage.jsx
@@ -162,11 +162,9 @@ class AccountSettingsPage extends React.Component {
       return countryList;
     }
 
-    return countryList.filter(({ value }) => {
-      const isDisabled = this.isDisabledCountry(value);
+    return countryList.filter(({ value, disabled }) => {
       const isUserCountry = value === committedValues.country;
-
-      return !isDisabled || isUserCountry;
+      return !disabled || isUserCountry;
     });
   };
 

--- a/src/account-settings/EditableSelectField.jsx
+++ b/src/account-settings/EditableSelectField.jsx
@@ -107,6 +107,7 @@ const EditableSelectField = (props) => {
             <option
               value={subOption.value}
               key={`${subOption.value}-${subOption.label}`}
+              disabled={subOption?.disabled}
             >
               {subOption.label}
             </option>
@@ -115,7 +116,7 @@ const EditableSelectField = (props) => {
       );
     }
     return (
-      <option value={option.value} key={`${option.value}-${option.label}`}>
+      <option value={option.value} key={`${option.value}-${option.label}`} disabled={option?.disabled}>
         {option.label}
       </option>
     );

--- a/src/account-settings/data/reducers.js
+++ b/src/account-settings/data/reducers.js
@@ -39,6 +39,7 @@ export const defaultState = {
   verifiedName: null,
   mostRecentVerifiedName: {},
   verifiedNameHistory: {},
+  disabledCountries: ['RU'],
 };
 
 const reducer = (state = defaultState, action = {}) => {

--- a/src/account-settings/data/selectors.js
+++ b/src/account-settings/data/selectors.js
@@ -206,6 +206,11 @@ const activeAccountSelector = createSelector(
   accountSettings => accountSettings.values.is_active,
 );
 
+const disabledCountriesSelector = createSelector(
+  accountSettingsSelector,
+  accountSettings => accountSettings.disabledCountries,
+);
+
 export const siteLanguageSelector = createSelector(
   previousSiteLanguageSelector,
   draftsSelector,
@@ -237,6 +242,7 @@ export const accountSettingsPageSelector = createSelector(
   mostRecentApprovedVerifiedNameValueSelector,
   mostRecentVerifiedNameSelector,
   sortedVerifiedNameHistorySelector,
+  disabledCountriesSelector,
   (
     accountSettings,
     siteLanguageOptions,
@@ -254,6 +260,7 @@ export const accountSettingsPageSelector = createSelector(
     verifiedName,
     mostRecentVerifiedName,
     verifiedNameHistory,
+    disabledCountries,
   ) => ({
     siteLanguageOptions,
     siteLanguage,
@@ -274,6 +281,7 @@ export const accountSettingsPageSelector = createSelector(
     verifiedName,
     mostRecentVerifiedName,
     verifiedNameHistory,
+    disabledCountries,
   }),
 );
 


### PR DESCRIPTION
[INF-1567](https://2u-internal.atlassian.net/browse/INF-1567)
### Description

- Countries in the `disabledCountries` list will no longer be visible to users in the account settings of other countries, and users will not be able to switch to disabled countries. 
- User with a disabled country selected can change their country to another one. After switching, they cannot select the disabled country again.
- Implemented frontend validation to verify the country against the disabled countries list to prevent invalid country submissions.

For Example, if Russia is on the disabled countries list.
> Other Country Users will not see Russia in the country list as an 
<img width="335" alt="Screenshot 2024-09-14 at 2 10 05 PM" src="https://github.com/user-attachments/assets/34e63032-8e9c-49a1-80a2-0ac19473fa86">
<img width="322" alt="Screenshot 2024-09-14 at 2 07 52 PM" src="https://github.com/user-attachments/assets/6198e8a9-7a8a-4255-a3be-60c5ac52bfe3">

------------------------------------------------------------------------------------------------------------------------
> Russian user will see Russia in the country list but it'll be disabled and they can change their country to another one.
<img width="350" alt="Screenshot 2024-09-14 at 2 09 07 PM" src="https://github.com/user-attachments/assets/278d6ab8-cb94-4067-9a9e-c0c7b24ecda3">
<img width="381" alt="Screenshot 2024-09-14 at 2 09 30 PM" src="https://github.com/user-attachments/assets/87e940da-8530-455f-8086-639a96a680c9">

------------------------------------------------------------------------------------------------------------------------
**Note**
- The disabledCountries list will be fetched from an API in phase 2 implementation.
