### PR TITLE
fix: send json accept headers for POST requests

### DIFF
--- a/src/account-settings/site-language/service.js
+++ b/src/account-settings/site-language/service.js
@@ -23,10 +23,15 @@ export async function patchPreferences(username, params) {
 
 export async function postSetLang(code) {
   const formData = new FormData();
+  const requestConfig = {
+    headers: {
+      Accept: 'application/json',
+      'X-Requested-With': 'XMLHttpRequest',
+    }
+  };
+  const url = `${getConfig().LMS_BASE_URL}/i18n/setlang/`;
   formData.append('language', code);
 
   await getAuthenticatedHttpClient()
-    .post(`${getConfig().LMS_BASE_URL}/i18n/setlang/`, formData, {
-      headers: { 'X-Requested-With': 'XMLHttpRequest' },
-    });
+    .post(url, formData, requestConfig);
 }

--- a/src/account-settings/site-language/service.js
+++ b/src/account-settings/site-language/service.js
@@ -27,7 +27,7 @@ export async function postSetLang(code) {
     headers: {
       Accept: 'application/json',
       'X-Requested-With': 'XMLHttpRequest',
-    }
+    },
   };
   const url = `${getConfig().LMS_BASE_URL}/i18n/setlang/`;
   formData.append('language', code);

--- a/src/account-settings/third-party-auth/data/service.js
+++ b/src/account-settings/third-party-auth/data/service.js
@@ -16,8 +16,9 @@ export async function getThirdPartyAuthProviders() {
 }
 
 export async function postDisconnectAuth(url) {
+  const requestConfig = { headers: { Accept: 'application/json' } };
   const { data } = await getAuthenticatedHttpClient()
-    .post(url)
+    .post(url, {}, requestConfig)
     .catch(handleRequestError);
   return data;
 }


### PR DESCRIPTION
### Description

This PR solves a CORS error when calling the endpoints for **Changing Site Language** and **Unlinking the SSO Account**. To resolve this error we simply specify the `Accept: 'application/json'` header in the request.

These are the related issues:
- https://github.com/openedx/frontend-app-account/issues/1052
- https://github.com/openedx/wg-build-test-release/issues/376

### Testing Instructions

The changes have been tested in a local environment with **Tutor v18.1.3**.

1. In your Tutor environment clone the Account MFE with these changes.
2. Create a mount with `tutor mounts add frontend-app-account`
3. Run `tutor dev start -d` to recreate the containers.
4. Inside the Account MFE folder run `npm install`
5. Finally run `tutor dev restart`

#### Changing Site Language
1. Go to the **Account Settings** > **Site Preferences**.
2. Click **Edit** next to **Site language**.
3. Pick a language.
4. Click **Save**.
5. CORS error does not appear.

#### Unlinking the SSO Account
1. Configure TPA auth for Open edX.
2. Login or Register via third-party authentication.
3. Go to **Account Settings** > **Linked Accounts**
4. Click Unlink {TPA_Name} account.
5. CORS error does not appear.

### Screenshots

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/ff959f41-f931-4b96-a063-e99db39ae23d) | ![image](https://github.com/user-attachments/assets/ab5ff1b4-c266-4be9-a989-36d243c77ce6) |
| ![image](https://github.com/user-attachments/assets/864ec2d7-3c02-46d8-995c-209b1571b621) | ![image](https://github.com/user-attachments/assets/14b946ab-adf1-4286-9628-37ab68b12e4f) |

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.