### PR TITLE
feat: remove learn more about IDV button

### DIFF
--- a/src/account-settings/AccountSettingsPage.jsx
+++ b/src/account-settings/AccountSettingsPage.jsx
@@ -14,7 +14,7 @@ import {
   getLanguageList,
 } from '@edx/frontend-platform/i18n';
 import {
-  Button, Hyperlink, Icon, Alert,
+  Hyperlink, Icon, Alert,
 } from '@openedx/paragon';
 import { CheckCircle, Error, WarningFilled } from '@openedx/paragon/icons';
 
@@ -311,19 +311,9 @@ class AccountSettingsPage extends React.Component {
         header={this.props.intl.formatMessage(messages['account.settings.field.name.verified.failure.message.header'])}
         body={
           (
-            <>
-              <div className="d-flex flex-row">
-                {this.props.intl.formatMessage(messages['account.settings.field.name.verified.failure.message'])}
-              </div>
-              <div className="d-flex flex-row-reverse mt-3">
-                <Button
-                  variant="primary"
-                  href="https://support.edx.org/hc/en-us/articles/360004381594-Why-was-my-ID-verification-denied"
-                >
-                  {this.props.intl.formatMessage(messages['account.settings.field.name.verified.failure.message.help.link'])}
-                </Button>{' '}
-              </div>
-            </>
+            <div className="d-flex flex-row">
+              {this.props.intl.formatMessage(messages['account.settings.field.name.verified.failure.message'])}
+            </div>
           )
         }
       />


### PR DESCRIPTION
### Description

The "Learn more about ID Verification" button that is displayed as part of the failed IDV notification lead to an inaccessible link. The button should be removed to prevent confusion.

#### How Has This Been Tested?

* Create a verified name via django admin for your test user, and mark the verified name as rejected
* Load the account settings page and ensure the "Learn more about ID Verification" button is not included in the verified name alert

#### Screenshots/sandbox (optional):

|Before|After|
|-------|-----|
|<img width="512" alt="verified_name_before" src="https://github.com/user-attachments/assets/ffecce93-f731-4e37-99db-671a58d80a8b">|![Screenshot 2024-10-21 at 2 45 20 PM](https://github.com/user-attachments/assets/3b31bac7-3f83-49e2-80a6-e51a8ece1f40)|


#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.