### PR TITLE
fix: send json accept headers for POST requests

### DIFF
--- a/src/account-settings/site-language/service.js
+++ b/src/account-settings/site-language/service.js
@@ -23,10 +23,15 @@ export async function patchPreferences(username, params) {
 
 export async function postSetLang(code) {
   const formData = new FormData();
+  const requestConfig = {
+    headers: {
+      Accept: 'application/json',
+      'X-Requested-With': 'XMLHttpRequest',
+    },
+  };
+  const url = `${getConfig().LMS_BASE_URL}/i18n/setlang/`;
   formData.append('language', code);
 
   await getAuthenticatedHttpClient()
-    .post(`${getConfig().LMS_BASE_URL}/i18n/setlang/`, formData, {
-      headers: { 'X-Requested-With': 'XMLHttpRequest' },
-    });
+    .post(url, formData, requestConfig);
 }

--- a/src/account-settings/third-party-auth/data/service.js
+++ b/src/account-settings/third-party-auth/data/service.js
@@ -16,8 +16,9 @@ export async function getThirdPartyAuthProviders() {
 }
 
 export async function postDisconnectAuth(url) {
+  const requestConfig = { headers: { Accept: 'application/json' } };
   const { data } = await getAuthenticatedHttpClient()
-    .post(url)
+    .post(url, {}, requestConfig)
     .catch(handleRequestError);
   return data;
 }


### PR DESCRIPTION
## Description
This PR solves a CORS error when calling the endpoints for Changing Site Language and Unlinking the SSO Account. To resolve this error we simply specify the Accept: 'application/json' header in the request.

These are the related issues:

https://github.com/openedx/frontend-app-account/issues/1052
https://github.com/openedx/wg-build-test-release/issues/376


#1139 backport