### PR TITLE
fix: updated notifications section url

### DIFF
--- a/src/account-settings/AccountSettingsPage.jsx
+++ b/src/account-settings/AccountSettingsPage.jsx
@@ -66,6 +66,7 @@ class AccountSettingsPage extends React.Component {
       '#basic-information': React.createRef(),
       '#profile-information': React.createRef(),
       '#social-media': React.createRef(),
+      '#notifications': React.createRef(),
       '#site-preferences': React.createRef(),
       '#linked-accounts': React.createRef(),
       '#delete-account': React.createRef(),
@@ -769,8 +770,9 @@ class AccountSettingsPage extends React.Component {
             {...editableFieldProps}
           />
         </div>
-        <div className="border border-light-700 my-6" />
-        <NotificationSettings />
+        <div id="notifications" ref={this.navLinkRefs['#notifications']}>
+          <NotificationSettings />
+        </div>
         <div className="account-section mb-5" id="site-preferences" ref={this.navLinkRefs['#site-preferences']}>
           <h2 className="section-heading h4 mb-3">
             {this.props.intl.formatMessage(messages['account.settings.section.site.preferences'])}

--- a/src/account-settings/JumpNav.jsx
+++ b/src/account-settings/JumpNav.jsx
@@ -19,6 +19,7 @@ const JumpNav = ({
           'basic-information',
           'profile-information',
           'social-media',
+          'notifications',
           'site-preferences',
           'linked-accounts',
           'delete-account',
@@ -39,6 +40,11 @@ const JumpNav = ({
         <li>
           <NavHashLink to="#social-media">
             {intl.formatMessage(messages['account.settings.section.social.media'])}
+          </NavHashLink>
+        </li>
+        <li>
+          <NavHashLink to="#notifications">
+            {intl.formatMessage(messages['notification.preferences.notifications.label'])}
           </NavHashLink>
         </li>
         <li>

--- a/src/account-settings/test/__snapshots__/JumpNav.test.jsx.snap
+++ b/src/account-settings/test/__snapshots__/JumpNav.test.jsx.snap
@@ -59,6 +59,19 @@ exports[`JumpNav should not render Optional Information or delete account link 1
           <a
             aria-current="page"
             className="active"
+            href="/#notifications"
+            isActive={[Function]}
+            onClick={[Function]}
+          >
+            Notifications
+          </a>
+        </li>
+        <li
+          className=""
+        >
+          <a
+            aria-current="page"
+            className="active"
             href="/#site-preferences"
             isActive={[Function]}
             onClick={[Function]}
@@ -136,6 +149,19 @@ exports[`JumpNav should render Optional Information and delete account link 1`] 
             onClick={[Function]}
           >
             Social Media Links
+          </a>
+        </li>
+        <li
+          className=""
+        >
+          <a
+            aria-current="page"
+            className="active"
+            href="/#notifications"
+            isActive={[Function]}
+            onClick={[Function]}
+          >
+            Notifications
           </a>
         </li>
         <li

--- a/src/notification-preferences/NotificationSettings.jsx
+++ b/src/notification-preferences/NotificationSettings.jsx
@@ -19,6 +19,7 @@ const NotificationSettings = () => {
   return (
     showPreferences && (
       <Container className="notification-preferences px-0">
+        <div className="border border-light-700 my-6" />
         <h2 className="notification-heading mb-3">
           {intl.formatMessage(messages.notificationHeading)}
         </h2>


### PR DESCRIPTION
### Description
Updated the notifications preferences section URL which is used on different MFEs to redirect the user to the notifications preferences center.

Old URL: `https://account.edx.org/notifications`
New URL: `https://account.edx.org/#notifications`