### PR TITLE
feat: implemented restricted countries functionalities

### DIFF
--- a/src/account-settings/AccountSettingsPage.jsx
+++ b/src/account-settings/AccountSettingsPage.jsx
@@ -152,14 +152,16 @@ class AccountSettingsPage extends React.Component {
   }));
 
   removeDisabledCountries = (countryList) => {
-    const { countries } = this.props;
+    const { countries, committedValues } = this.props;
 
     if (!countries.length) {
       return countryList;
     }
 
-    return countryList.filter(({ value }) => value === this.props?.committedValues?.country
-    || new Set(countries.map(({ code }) => code)).has(value));
+    const allowedCountries = new Set(countries.map(({ code }) => code));
+    const committedCountry = committedValues?.country;
+
+    return countryList.filter(({ value }) => value === committedCountry || allowedCountries.has(value));
   };
 
   handleEditableFieldChange = (name, value) => {
@@ -214,8 +216,9 @@ class AccountSettingsPage extends React.Component {
 
   isDisabledCountry = (country) => {
     const { countries } = this.props;
+    const allowedCountries = new Set(countries.map(({ code }) => code));
 
-    return countries.length > 0 && !new Set(countries.map(({ code }) => code)).has(country);
+    return countries.length > 0 && !allowedCountries.has(country);
   };
 
   isEditable(fieldName) {

--- a/src/account-settings/AccountSettingsPage.jsx
+++ b/src/account-settings/AccountSettingsPage.jsx
@@ -47,6 +47,7 @@ import {
   COPPA_COMPLIANCE_YEAR,
   WORK_EXPERIENCE_OPTIONS,
   getStatesList,
+  FIELD_LABELS,
 } from './data/constants';
 import { fetchSiteLanguages } from './site-language';
 import { fetchCourseList } from '../notification-preferences/data/thunks';
@@ -157,9 +158,8 @@ class AccountSettingsPage extends React.Component {
       return countryList;
     }
 
-    return countryList.filter(({ value }) => {
-      return value === this.props?.committedValues?.country || new Set(countries.map(({value}) => value)).has(value);
-    });
+    return countryList.filter(({ value }) => value === this.props?.committedValues?.country
+    || new Set(countries.map(({ code }) => code)).has(value));
   };
 
   handleEditableFieldChange = (name, value) => {
@@ -167,10 +167,10 @@ class AccountSettingsPage extends React.Component {
   };
 
   handleSubmit = (formId, values) => {
-    if (formId === 'country' && this.isDisabledCountry(values)) {
+    if (formId === FIELD_LABELS.COUNTRY && this.isDisabledCountry(values)) {
       return;
     }
-    
+
     const { formValues } = this.props;
     let extendedProfileObject = {};
 
@@ -213,9 +213,9 @@ class AccountSettingsPage extends React.Component {
   };
 
   isDisabledCountry = (country) => {
-    const {countries} = this.props;
-    
-    return countries.length > 0 && !new Set(countries.map(({value}) => value)).has(country);
+    const { countries } = this.props;
+
+    return countries.length > 0 && !new Set(countries.map(({ code }) => code)).has(country);
   };
 
   isEditable(fieldName) {

--- a/src/account-settings/EditableSelectField.jsx
+++ b/src/account-settings/EditableSelectField.jsx
@@ -107,6 +107,7 @@ const EditableSelectField = (props) => {
             <option
               value={subOption.value}
               key={`${subOption.value}-${subOption.label}`}
+              disabled={subOption?.disabled}
             >
               {subOption.label}
             </option>
@@ -115,7 +116,7 @@ const EditableSelectField = (props) => {
       );
     }
     return (
-      <option value={option.value} key={`${option.value}-${option.label}`}>
+      <option value={option.value} key={`${option.value}-${option.label}`} disabled={option?.disabled}>
         {option.label}
       </option>
     );

--- a/src/account-settings/data/actions.js
+++ b/src/account-settings/data/actions.js
@@ -27,6 +27,7 @@ export const fetchSettingsSuccess = ({
   profileDataManager,
   timeZones,
   verifiedNameHistory,
+  countries,
 }) => ({
   type: FETCH_SETTINGS.SUCCESS,
   payload: {
@@ -35,6 +36,7 @@ export const fetchSettingsSuccess = ({
     profileDataManager,
     timeZones,
     verifiedNameHistory,
+    countries,
   },
 });
 

--- a/src/account-settings/data/constants.js
+++ b/src/account-settings/data/constants.js
@@ -132,6 +132,10 @@ export function getStatesList(country) {
   return country && COUNTRY_STATES_MAP[country.toUpperCase()];
 }
 
+export const FIELD_LABELS = {
+  COUNTRY: 'country',
+};
+
 export const DECLINED = 'declined';
 export const SELF_DESCRIBE = 'self-describe';
 export const OTHER = 'other';

--- a/src/account-settings/data/reducers.js
+++ b/src/account-settings/data/reducers.js
@@ -39,6 +39,7 @@ export const defaultState = {
   verifiedName: null,
   mostRecentVerifiedName: {},
   verifiedNameHistory: {},
+  countries: [],
 };
 
 const reducer = (state = defaultState, action = {}) => {
@@ -64,6 +65,7 @@ const reducer = (state = defaultState, action = {}) => {
         loaded: true,
         loadingError: null,
         verifiedNameHistory: action.payload.verifiedNameHistory,
+        countries: action.payload.countries,
       };
     case FETCH_SETTINGS.FAILURE:
       return {

--- a/src/account-settings/data/sagas.js
+++ b/src/account-settings/data/sagas.js
@@ -53,7 +53,7 @@ export function* handleFetchSettings() {
     const { username, userId, roles: userRoles } = getAuthenticatedUser();
 
     const {
-      thirdPartyAuthProviders, profileDataManager, timeZones, ...values
+      thirdPartyAuthProviders, profileDataManager, timeZones, countries, ...values
     } = yield call(
       getSettings,
       username,
@@ -71,6 +71,7 @@ export function* handleFetchSettings() {
       profileDataManager,
       timeZones,
       verifiedNameHistory,
+      countries,
     }));
   } catch (e) {
     yield put(fetchSettingsFailure(e.message));

--- a/src/account-settings/data/selectors.js
+++ b/src/account-settings/data/selectors.js
@@ -88,6 +88,11 @@ const previousSiteLanguageSelector = createSelector(
   accountSettings => accountSettings.previousSiteLanguage,
 );
 
+const countriesSelector = createSelector(
+  accountSettingsSelector,
+  accountSettings => accountSettings.countries,
+);
+
 const editableFieldErrorSelector = createSelector(
   editableFieldNameSelector,
   accountSettingsSelector,
@@ -237,6 +242,7 @@ export const accountSettingsPageSelector = createSelector(
   mostRecentApprovedVerifiedNameValueSelector,
   mostRecentVerifiedNameSelector,
   sortedVerifiedNameHistorySelector,
+  countriesSelector,
   (
     accountSettings,
     siteLanguageOptions,
@@ -254,6 +260,7 @@ export const accountSettingsPageSelector = createSelector(
     verifiedName,
     mostRecentVerifiedName,
     verifiedNameHistory,
+    countries,
   ) => ({
     siteLanguageOptions,
     siteLanguage,
@@ -274,6 +281,7 @@ export const accountSettingsPageSelector = createSelector(
     verifiedName,
     mostRecentVerifiedName,
     verifiedNameHistory,
+    countries,
   }),
 );
 

--- a/src/account-settings/data/service.js
+++ b/src/account-settings/data/service.js
@@ -186,9 +186,18 @@ export async function postVerifiedName(data) {
     .catch(error => handleRequestError(error));
 }
 
+export async function getCountryList() {
+  const { data } = await getAuthenticatedHttpClient()
+    .get(`${getConfig().LMS_BASE_URL}/user_api/v1/account/registration/`);
+
+  return data?.fields
+    .find(({ name }) => name === 'country')
+    ?.options?.map(({ value, name }) => ({ value, label: name })) || [];
+}
+
 /**
- * A single function to GET everything considered a setting. Currently encapsulates Account, Preferences, and
- * ThirdPartyAuth.
+ * A single function to GET everything considered a setting. Currently encapsulates Account, Preferences, countriesList
+ * and ThirdPartyAuth.
  */
 export async function getSettings(username, userRoles) {
   const [
@@ -197,12 +206,14 @@ export async function getSettings(username, userRoles) {
     thirdPartyAuthProviders,
     profileDataManager,
     timeZones,
+    countries,
   ] = await Promise.all([
     getAccount(username),
     getPreferences(username),
     getThirdPartyAuthProviders(),
     getProfileDataManager(username, userRoles),
     getTimeZones(),
+    getCountryList(),
   ]);
 
   return {
@@ -211,6 +222,7 @@ export async function getSettings(username, userRoles) {
     thirdPartyAuthProviders,
     profileDataManager,
     timeZones,
+    countries,
   };
 }
 

--- a/src/account-settings/data/service.js
+++ b/src/account-settings/data/service.js
@@ -189,7 +189,6 @@ export async function postVerifiedName(data) {
 }
 
 function extractCountryList(data) {
-  console.log(FIELD_LABELS);
   return data?.fields
     .find(({ name }) => name === FIELD_LABELS.COUNTRY)
     ?.options?.map(({ value, name }) => ({ code: value, name })) || [];

--- a/src/account-settings/data/service.js
+++ b/src/account-settings/data/service.js
@@ -1,5 +1,6 @@
 import { getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { logError } from '@edx/frontend-platform/logging';
 import pick from 'lodash.pick';
 import omit from 'lodash.omit';
 import isEmpty from 'lodash.isempty';
@@ -7,6 +8,7 @@ import isEmpty from 'lodash.isempty';
 import { handleRequestError, unpackFieldErrors } from './utils';
 import { getThirdPartyAuthProviders } from '../third-party-auth';
 import { postVerifiedNameConfig } from '../certificate-preference/data/service';
+import { FIELD_LABELS } from './constants';
 
 const SOCIAL_PLATFORMS = [
   { id: 'twitter', key: 'social_link_twitter' },
@@ -186,15 +188,24 @@ export async function postVerifiedName(data) {
     .catch(error => handleRequestError(error));
 }
 
-export async function getCountryList() {
-  const { data } = await getAuthenticatedHttpClient()
-    .get(`${getConfig().LMS_BASE_URL}/user_api/v1/account/registration/`);
-
+function extractCountryList(data) {
+  console.log(FIELD_LABELS);
   return data?.fields
-    .find(({ name }) => name === 'country')
-    ?.options?.map(({ value, name }) => ({ value, label: name })) || [];
+    .find(({ name }) => name === FIELD_LABELS.COUNTRY)
+    ?.options?.map(({ value, name }) => ({ code: value, name })) || [];
 }
 
+export async function getCountryList() {
+  const url = `${getConfig().LMS_BASE_URL}/user_api/v1/account/registration/`;
+
+  try {
+    const { data } = await getAuthenticatedHttpClient().get(url);
+    return extractCountryList(data);
+  } catch (e) {
+    logError(e);
+    return [];
+  }
+}
 /**
  * A single function to GET everything considered a setting. Currently encapsulates Account, Preferences, countriesList
  * and ThirdPartyAuth.


### PR DESCRIPTION
### Description

We are introducing a feature that allows platform administrators to restrict users from selecting one or more countries in Account MFEs.

#### How Has This Been Tested?

We retrieved the list of restricted countries by calling the following API:

👉 https://courses.edx.org/user_api/v1/account/registration/

At the same time, we obtained the translated country names using the i18n-iso-countries package.

Once both datasets were available, we filtered out the restricted countries from the translated list and displayed the updated country list in the UI.

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/2u-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.