### PR TITLE
fix: changed frequency from never to daily on email  preference change

### DIFF
--- a/src/notification-preferences/EmailCadences.jsx
+++ b/src/notification-preferences/EmailCadences.jsx
@@ -10,7 +10,7 @@ import {
 } from '@openedx/paragon';
 
 import messages from './messages';
-import EMAIL_CADENCE from './data/constants';
+import { EMAIL_CADENCE_PREFERENCES, EMAIL_CADENCE } from './data/constants';
 import { selectUpdatePreferencesStatus } from './data/selectors';
 import { LOADING_STATUS } from '../constants';
 
@@ -44,12 +44,12 @@ const EmailCadences = ({
           className="bg-white shadow d-flex flex-column margin-left-2"
           data-testid="email-cadence-dropdown"
         >
-          {Object.values(EMAIL_CADENCE).map((cadence) => (
+          {Object.values(EMAIL_CADENCE_PREFERENCES).map((cadence) => (
             <Dropdown.Item
               key={cadence}
               as={Button}
               variant="tertiary"
-              name="email_cadence"
+              name={EMAIL_CADENCE}
               className="d-flex justify-content-start py-1.5 font-size-14 cadence-button"
               size="inline"
               active={cadence === emailCadence}
@@ -71,7 +71,7 @@ const EmailCadences = ({
 EmailCadences.propTypes = {
   email: PropTypes.bool.isRequired,
   onToggle: PropTypes.func.isRequired,
-  emailCadence: PropTypes.oneOf(Object.values(EMAIL_CADENCE)).isRequired,
+  emailCadence: PropTypes.oneOf(Object.values(EMAIL_CADENCE_PREFERENCES)).isRequired,
   notificationType: PropTypes.string.isRequired,
 };
 

--- a/src/notification-preferences/NotificationPreferenceColumn.jsx
+++ b/src/notification-preferences/NotificationPreferenceColumn.jsx
@@ -46,7 +46,7 @@ const NotificationPreferenceColumn = ({ appId, channel, appPreference }) => {
     return emailCadence;
   }, []);
 
-  const onToggle = useCallback(async (event, notificationType) => {
+  const onToggle = useCallback((event, notificationType) => {
     const { name: notificationChannel, checked, innerText } = event.target;
     const appNotificationPreference = appPreferences.find(preference => preference.id === notificationType);
 
@@ -58,24 +58,14 @@ const NotificationPreferenceColumn = ({ appId, channel, appPreference }) => {
       appNotificationPreference.emailCadence,
     );
 
-    const updatePreference = async (appChannel, appValue, cadence) => {
-      await dispatch(updatePreferenceToggle(
-        courseId,
-        appId,
-        notificationType,
-        appChannel,
-        appValue,
-        cadence !== MIXED ? cadence : undefined,
-      ));
-    };
-
-    // Update the main preference
-    await updatePreference(notificationChannel, value, emailCadence);
-
-    // Handle the special case for EMAIL and checked
-    if (notificationChannel === EMAIL && checked) {
-      await updatePreference(EMAIL_CADENCE, undefined, emailCadence);
-    }
+    dispatch(updatePreferenceToggle(
+      courseId,
+      appId,
+      notificationType,
+      notificationChannel,
+      value,
+      emailCadence !== MIXED ? emailCadence : undefined,
+    ));
   }, [appPreferences, getValue, getEmailCadence, dispatch, courseId, appId]);
 
   const renderPreference = (preference) => (

--- a/src/notification-preferences/NotificationPreferenceColumn.jsx
+++ b/src/notification-preferences/NotificationPreferenceColumn.jsx
@@ -15,6 +15,9 @@ import { LOADING_STATUS } from '../constants';
 import { updatePreferenceToggle } from './data/thunks';
 import { selectAppPreferences, selectSelectedCourseId, selectUpdatePreferencesStatus } from './data/selectors';
 import { notificationChannels, shouldHideAppPreferences } from './data/utils';
+import {
+  EMAIL, EMAIL_CADENCE, EMAIL_CADENCE_PREFERENCES, MIXED,
+} from './data/constants';
 
 const NotificationPreferenceColumn = ({ appId, channel, appPreference }) => {
   const dispatch = useDispatch();
@@ -26,22 +29,54 @@ const NotificationPreferenceColumn = ({ appId, channel, appPreference }) => {
   const NOTIFICATION_CHANNELS = Object.values(notificationChannels());
   const hideAppPreferences = shouldHideAppPreferences(appPreferences, appId) || false;
 
-  const onToggle = useCallback((event, notificationType) => {
-    const { name: notificationChannel } = event.target;
-    const appNotificationPreference = appPreferences.find(preference => preference.id === notificationType);
-    const value = notificationChannel === 'email_cadence' && courseId ? event.target.innerText : event.target.checked;
-    const emailCadence = notificationChannel === 'email_cadence' ? event.target.innerText : appNotificationPreference.emailCadence;
+  const getValue = useCallback((notificationChannel, innerText, checked) => {
+    if (notificationChannel === EMAIL_CADENCE && courseId) {
+      return innerText;
+    }
+    return checked;
+  }, [courseId]);
 
-    dispatch(updatePreferenceToggle(
-      courseId,
-      appId,
-      notificationType,
+  const getEmailCadence = useCallback((notificationChannel, checked, innerText, emailCadence) => {
+    if (notificationChannel === EMAIL_CADENCE) {
+      return innerText;
+    }
+    if (notificationChannel === EMAIL && checked) {
+      return EMAIL_CADENCE_PREFERENCES.DAILY;
+    }
+    return emailCadence;
+  }, []);
+
+  const onToggle = useCallback(async (event, notificationType) => {
+    const { name: notificationChannel, checked, innerText } = event.target;
+    const appNotificationPreference = appPreferences.find(preference => preference.id === notificationType);
+
+    const value = getValue(notificationChannel, innerText, checked);
+    const emailCadence = getEmailCadence(
       notificationChannel,
-      value,
-      emailCadence !== 'Mixed' ? emailCadence : undefined,
-    ));
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [appId, appPreferences]);
+      checked,
+      innerText,
+      appNotificationPreference.emailCadence,
+    );
+
+    const updatePreference = async (appChannel, appValue, cadence) => {
+      await dispatch(updatePreferenceToggle(
+        courseId,
+        appId,
+        notificationType,
+        appChannel,
+        appValue,
+        cadence !== MIXED ? cadence : undefined,
+      ));
+    };
+
+    // Update the main preference
+    await updatePreference(notificationChannel, value, emailCadence);
+
+    // Handle the special case for EMAIL and checked
+    if (notificationChannel === EMAIL && checked) {
+      await updatePreference(EMAIL_CADENCE, undefined, emailCadence);
+    }
+  }, [appPreferences, getValue, getEmailCadence, dispatch, courseId, appId]);
 
   const renderPreference = (preference) => (
     (preference?.coreNotificationTypes?.length > 0 || preference.id !== 'core') && (
@@ -63,7 +98,7 @@ const NotificationPreferenceColumn = ({ appId, channel, appPreference }) => {
         id={`${preference.id}-${channel}`}
         className="my-1"
       />
-      {channel === 'email' && (
+      {channel === EMAIL && (
       <EmailCadences
         email={preference.email}
         onToggle={onToggle}

--- a/src/notification-preferences/data/constants.js
+++ b/src/notification-preferences/data/constants.js
@@ -1,6 +1,7 @@
-const EMAIL_CADENCE = {
+export const EMAIL_CADENCE_PREFERENCES = {
   DAILY: 'Daily',
   WEEKLY: 'Weekly',
 };
-
-export default EMAIL_CADENCE;
+export const EMAIL_CADENCE = 'email_cadence';
+export const EMAIL = 'email';
+export const MIXED = 'Mixed';

--- a/src/notification-preferences/data/thunks.js
+++ b/src/notification-preferences/data/thunks.js
@@ -1,6 +1,6 @@
 import { camelCaseObject } from '@edx/frontend-platform';
 import camelCase from 'lodash.camelcase';
-import EMAIL_CADENCE from './constants';
+import { EMAIL_CADENCE_PREFERENCES } from './constants';
 import {
   fetchCourseListSuccess,
   fetchCourseListFetching,
@@ -79,7 +79,8 @@ const normalizePreferences = (responseData, courseId) => {
         push: preferences[appId].notificationTypes[preferenceId].push,
         email: preferences[appId].notificationTypes[preferenceId].email,
         info: preferences[appId].notificationTypes[preferenceId].info || '',
-        emailCadence: preferences[appId].notificationTypes[preferenceId].emailCadence || EMAIL_CADENCE.DAILY,
+        emailCadence: preferences[appId].notificationTypes[preferenceId].emailCadence
+        || EMAIL_CADENCE_PREFERENCES.DAILY,
         coreNotificationTypes: preferences[appId].coreNotificationTypes || [],
       }
     ));

--- a/src/notification-preferences/data/thunks.js
+++ b/src/notification-preferences/data/thunks.js
@@ -1,6 +1,6 @@
 import { camelCaseObject } from '@edx/frontend-platform';
 import camelCase from 'lodash.camelcase';
-import { EMAIL_CADENCE_PREFERENCES } from './constants';
+import { EMAIL, EMAIL_CADENCE, EMAIL_CADENCE_PREFERENCES } from './constants';
 import {
   fetchCourseListSuccess,
   fetchCourseListFetching,
@@ -166,6 +166,18 @@ export const updatePreferenceToggle = (
           emailCadence,
         );
         dispatch(fetchNotificationPreferenceSuccess(courseId, camelCaseObject(data), true));
+
+        if (notificationChannel === EMAIL && value) {
+          data = await postPreferenceToggle(
+            notificationApp,
+            notificationType,
+            EMAIL_CADENCE,
+            undefined,
+            EMAIL_CADENCE_PREFERENCES.DAILY,
+          );
+
+          dispatch(fetchNotificationPreferenceSuccess(courseId, camelCaseObject(data), true));
+        }
       }
     } catch (errors) {
       dispatch(updatePreferenceValue(


### PR DESCRIPTION
[INF-1797](https://2u-internal.atlassian.net/browse/INF-1797)

### Description

We deprecated the “Never” email frequency for emails a while ago.

However, it is still persisting for people who had selected it before deprecation. Even if someone turns on email notifications toggle, “Never” persists.

**Acceptance Criteria**

Modify UX such that when a person turns on email toggle for a preference from COURSE or ACCOUNT level, the email cadences for that preference should change to “Daily” no matter what it was before (Never/Weekly/Daily). 

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.