### PR TITLE
fix: fixed course level preference issue

### DIFF
--- a/src/notification-preferences/data/constants.js
+++ b/src/notification-preferences/data/constants.js
@@ -5,3 +5,14 @@ export const EMAIL_CADENCE_PREFERENCES = {
 export const EMAIL_CADENCE = 'email_cadence';
 export const EMAIL = 'email';
 export const MIXED = 'Mixed';
+export const RequestStatus = /** @type {const} */ ({
+  IN_PROGRESS: 'in-progress',
+  SUCCESSFUL: 'successful',
+  FAILED: 'failed',
+  DENIED: 'denied',
+  PENDING: 'pending',
+  CLEAR: 'clear',
+  PARTIAL: 'partial',
+  PARTIAL_FAILURE: 'partial failure',
+  NOT_FOUND: 'not-found',
+});

--- a/src/notification-preferences/data/thunk.test.js
+++ b/src/notification-preferences/data/thunk.test.js
@@ -1,0 +1,150 @@
+import { updatePreferenceToggle } from './thunks';
+import {
+  updatePreferenceValue,
+  fetchNotificationPreferenceSuccess,
+  fetchNotificationPreferenceFailed,
+} from './actions';
+import { patchPreferenceToggle, postPreferenceToggle } from './service';
+import { EMAIL } from './constants';
+
+jest.mock('./service', () => ({
+  patchPreferenceToggle: jest.fn(),
+  postPreferenceToggle: jest.fn(),
+}));
+
+jest.mock('./actions', () => ({
+  updatePreferenceValue: jest.fn(),
+  fetchNotificationPreferenceSuccess: jest.fn(),
+  fetchNotificationPreferenceFailed: jest.fn(),
+}));
+
+describe('updatePreferenceToggle', () => {
+  const dispatch = jest.fn();
+  const courseId = 'course-v1:edX+DemoX+2023';
+  const notificationApp = 'app';
+  const notificationType = 'type';
+  const notificationChannel = 'channel';
+  const value = true;
+  const emailCadence = 'daily';
+
+  const mockData = {
+    updated_value: false,
+    notification_type: 'ora_grade_assigned',
+    channel: 'email',
+    app: 'grading',
+    successfully_updated_courses: [
+      {
+        course_id: 'course-v1:ACCA+ColSid+1T2024',
+        current_setting: {
+          web: false,
+          push: false,
+          email: false,
+          email_cadence: 'Weekly',
+        },
+      },
+      {
+        course_id: 'course-v1:arbisoft_acca+cs1023+2021_T4',
+        current_setting: {
+          web: false,
+          push: false,
+          email: false,
+          email_cadence: 'Weekly',
+        },
+      },
+    ],
+    total_updated: 2,
+    total_courses: 2,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should update preference for a course-specific notification', async () => {
+    patchPreferenceToggle.mockResolvedValue({ data: mockData });
+    await updatePreferenceToggle(
+      courseId,
+      notificationApp,
+      notificationType,
+      notificationChannel,
+      value,
+      emailCadence,
+    )(dispatch);
+
+    expect(dispatch).toHaveBeenCalledWith(updatePreferenceValue(
+      notificationApp,
+      notificationType,
+      notificationChannel,
+      !value,
+    ));
+    expect(patchPreferenceToggle).toHaveBeenCalledWith(
+      courseId,
+      notificationApp,
+      notificationType,
+      notificationChannel,
+      value,
+    );
+    expect(dispatch).toHaveBeenCalledWith(fetchNotificationPreferenceSuccess(courseId, { data: mockData }, false));
+  });
+
+  it('should update preference globally when courseId is not provided', async () => {
+    postPreferenceToggle.mockResolvedValue({ data: mockData });
+    await updatePreferenceToggle(
+      null,
+      notificationApp,
+      notificationType,
+      notificationChannel,
+      value,
+      emailCadence,
+    )(dispatch);
+
+    expect(dispatch).toHaveBeenCalledWith(updatePreferenceValue(
+      notificationApp,
+      notificationType,
+      notificationChannel,
+      !value,
+    ));
+    expect(postPreferenceToggle).toHaveBeenCalledWith(
+      notificationApp,
+      notificationType,
+      notificationChannel,
+      value,
+      emailCadence,
+    );
+    expect(dispatch).toHaveBeenCalledWith(fetchNotificationPreferenceSuccess(null, { data: mockData }, true));
+  });
+
+  it('should handle email preferences separately', async () => {
+    patchPreferenceToggle.mockResolvedValue({ data: mockData });
+    await updatePreferenceToggle(courseId, notificationApp, notificationType, EMAIL, value, emailCadence)(dispatch);
+
+    expect(patchPreferenceToggle).toHaveBeenCalledWith(
+      courseId,
+      notificationApp,
+      notificationType,
+      EMAIL,
+      true,
+    );
+    expect(dispatch).toHaveBeenCalledWith(fetchNotificationPreferenceSuccess(courseId, { data: mockData }, false));
+  });
+
+  it('should dispatch fetchNotificationPreferenceFailed on error', async () => {
+    patchPreferenceToggle.mockRejectedValue(new Error('Network Error'));
+    await updatePreferenceToggle(
+      courseId,
+      notificationApp,
+      notificationType,
+      notificationChannel,
+      value,
+      emailCadence,
+    )(dispatch);
+
+    expect(dispatch).toHaveBeenCalledWith(updatePreferenceValue(
+      notificationApp,
+      notificationType,
+      notificationChannel,
+      !value,
+    ));
+    expect(dispatch).toHaveBeenCalledWith(fetchNotificationPreferenceFailed());
+  });
+});

--- a/src/notification-preferences/data/thunks.js
+++ b/src/notification-preferences/data/thunks.js
@@ -137,43 +137,68 @@ export const updatePreferenceToggle = (
   notificationChannel,
   value,
   emailCadence,
-) => async (dispatch) => {
-  try {
-    dispatch(updatePreferenceValue(notificationApp, notificationType, notificationChannel, !value));
-
-    const togglePreference = courseId
-      ? (cId, app, type, channel, val) => patchPreferenceToggle(cId, app, type, channel, val)
-      : (app, type, channel, val, cadence) => postPreferenceToggle(app, type, channel, val, cadence);
-
-    let data = courseId
-      ? await togglePreference(courseId, notificationApp, notificationType, notificationChannel, value)
-      : await togglePreference(notificationApp, notificationType, notificationChannel, value, emailCadence);
-
-    let normalizedData = courseId ? normalizePreferences(camelCaseObject(data), courseId) : camelCaseObject(data);
-    dispatch(fetchNotificationPreferenceSuccess(courseId, normalizedData, !courseId));
-
-    if (notificationChannel === EMAIL && value) {
-      data = courseId
-        ? await togglePreference(
+) => (
+  async (dispatch) => {
+    try {
+      dispatch(updatePreferenceValue(
+        notificationApp,
+        notificationType,
+        notificationChannel,
+        !value,
+      ));
+      let data = null;
+      if (courseId) {
+        data = await patchPreferenceToggle(
           courseId,
           notificationApp,
           notificationType,
-          EMAIL_CADENCE,
-          EMAIL_CADENCE_PREFERENCES.DAILY,
-        )
-        : await togglePreference(
+          notificationChannel,
+          value,
+        );
+        let normalizedData = normalizePreferences(camelCaseObject(data), courseId);
+        dispatch(fetchNotificationPreferenceSuccess(courseId, normalizedData));
+
+        if (notificationChannel === EMAIL && value) {
+          data = await patchPreferenceToggle(
+            courseId,
+            notificationApp,
+            notificationType,
+            EMAIL_CADENCE,
+            EMAIL_CADENCE_PREFERENCES.DAILY,
+          );
+          normalizedData = normalizePreferences(camelCaseObject(data), courseId);
+          dispatch(fetchNotificationPreferenceSuccess(courseId, normalizedData));
+        }
+      } else {
+        data = await postPreferenceToggle(
           notificationApp,
           notificationType,
-          EMAIL_CADENCE,
-          undefined,
-          EMAIL_CADENCE_PREFERENCES.DAILY,
+          notificationChannel,
+          value,
+          emailCadence,
         );
+        dispatch(fetchNotificationPreferenceSuccess(courseId, camelCaseObject(data), true));
 
-      normalizedData = courseId ? normalizePreferences(camelCaseObject(data), courseId) : camelCaseObject(data);
-      dispatch(fetchNotificationPreferenceSuccess(courseId, normalizedData, !courseId));
+        if (notificationChannel === EMAIL && value) {
+          data = await postPreferenceToggle(
+            notificationApp,
+            notificationType,
+            EMAIL_CADENCE,
+            undefined,
+            EMAIL_CADENCE_PREFERENCES.DAILY,
+          );
+
+          dispatch(fetchNotificationPreferenceSuccess(courseId, camelCaseObject(data), true));
+        }
+      }
+    } catch (errors) {
+      dispatch(updatePreferenceValue(
+        notificationApp,
+        notificationType,
+        notificationChannel,
+        !value,
+      ));
+      dispatch(fetchNotificationPreferenceFailed());
     }
-  } catch (errors) {
-    dispatch(updatePreferenceValue(notificationApp, notificationType, notificationChannel, !value));
-    dispatch(fetchNotificationPreferenceFailed());
   }
-};
+);

--- a/src/notification-preferences/data/thunks.js
+++ b/src/notification-preferences/data/thunks.js
@@ -140,56 +140,58 @@ export const updatePreferenceToggle = (
 ) => (
   async (dispatch) => {
     try {
+      // Initially update the UI to give immediate feedback
       dispatch(updatePreferenceValue(
         notificationApp,
         notificationType,
         notificationChannel,
         !value,
       ));
-      let data = null;
-      if (courseId) {
-        data = await patchPreferenceToggle(
-          courseId,
-          notificationApp,
-          notificationType,
-          notificationChannel,
-          value,
-        );
-        let normalizedData = normalizePreferences(camelCaseObject(data), courseId);
-        dispatch(fetchNotificationPreferenceSuccess(courseId, normalizedData));
 
-        if (notificationChannel === EMAIL && value) {
-          data = await patchPreferenceToggle(
+      // Function to handle data normalization and dispatching success
+      const handleSuccessResponse = (data, isGlobal = false) => {
+        const processedData = courseId
+          ? normalizePreferences(camelCaseObject(data), courseId)
+          : camelCaseObject(data);
+
+        dispatch(fetchNotificationPreferenceSuccess(courseId, processedData, isGlobal));
+        return processedData;
+      };
+
+      // Function to toggle preference based on context (course-specific or global)
+      const togglePreference = async (channel, toggleValue, cadence) => {
+        if (courseId) {
+          return patchPreferenceToggle(
             courseId,
             notificationApp,
             notificationType,
-            EMAIL_CADENCE,
-            EMAIL_CADENCE_PREFERENCES.DAILY,
+            channel,
+            channel === EMAIL_CADENCE ? cadence : toggleValue,
           );
-          normalizedData = normalizePreferences(camelCaseObject(data), courseId);
-          dispatch(fetchNotificationPreferenceSuccess(courseId, normalizedData));
         }
-      } else {
-        data = await postPreferenceToggle(
+
+        return postPreferenceToggle(
           notificationApp,
           notificationType,
-          notificationChannel,
-          value,
-          emailCadence,
+          channel,
+          channel === EMAIL_CADENCE ? undefined : toggleValue,
+          cadence,
         );
-        dispatch(fetchNotificationPreferenceSuccess(courseId, camelCaseObject(data), true));
+      };
 
-        if (notificationChannel === EMAIL && value) {
-          data = await postPreferenceToggle(
-            notificationApp,
-            notificationType,
-            EMAIL_CADENCE,
-            undefined,
-            EMAIL_CADENCE_PREFERENCES.DAILY,
-          );
+      // Execute the main preference toggle
+      const data = await togglePreference(notificationChannel, value, emailCadence);
+      handleSuccessResponse(data, !courseId);
 
-          dispatch(fetchNotificationPreferenceSuccess(courseId, camelCaseObject(data), true));
-        }
+      // Handle special case for email notifications
+      if (notificationChannel === EMAIL && value) {
+        const emailCadenceData = await togglePreference(
+          EMAIL_CADENCE,
+          courseId ? undefined : value,
+          EMAIL_CADENCE_PREFERENCES.DAILY,
+        );
+
+        handleSuccessResponse(emailCadenceData, !courseId);
       }
     } catch (errors) {
       dispatch(updatePreferenceValue(


### PR DESCRIPTION
[INF-1797](https://2u-internal.atlassian.net/browse/INF-1797)

### Description

We deprecated the “Never” email frequency for emails a while ago.

However, it is still persisting for people who had selected it before deprecation. Even if someone turns on email notifications toggle, “Never” persists.

**Acceptance Criteria**

Modify UX such that when a person turns on email toggle for a preference from COURSE or ACCOUNT level, the email cadences for that preference should change to “Daily” no matter what it was before (Never/Weekly/Daily). 

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.