### PR TITLE
chore: temporarily disabled notification preferences course dropdown

### DIFF
--- a/src/notification-preferences/NotificationCoursesDropdown.jsx
+++ b/src/notification-preferences/NotificationCoursesDropdown.jsx
@@ -43,6 +43,7 @@ const NotificationCoursesDropdown = () => {
             variant="outline-primary"
             id="course-dropdown-btn"
             className="w-100 justify-content-between small"
+            disabled
           >
             {selectedCourse?.name}
           </Dropdown.Toggle>


### PR DESCRIPTION
### Description

Temporarily disabled notification preferences course dropdown.

To reduce code complexity and respect account level settings for existing users enrolling in new courses, we want to get rid of course level preferences entirely. For this we are disabling dropdown temporarily. In case, users who want to use course level preference will feel some inconvenience, we will get a support request.

Ticket: [INF-1886](https://2u-internal.atlassian.net/browse/INF-1886)

#### How Has This Been Tested?

Please describe in detail how you tested your changes.

#### Screenshots/sandbox (optional):
Include a link to the sandbox for design changes or screenshot for before and after. **Remove this section if it's not applicable.**

|Before|After|
|-------|-----|
|      |      |

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.