### PR TITLE
fix: use Container component with size='xl'

### DIFF
--- a/src/account-settings/AccountSettingsPage.jsx
+++ b/src/account-settings/AccountSettingsPage.jsx
@@ -14,7 +14,7 @@ import {
   getLanguageList,
 } from '@edx/frontend-platform/i18n';
 import {
-  Hyperlink, Icon, Alert,
+  Container, Hyperlink, Icon, Alert,
 } from '@openedx/paragon';
 import { CheckCircle, Error, WarningFilled } from '@openedx/paragon/icons';
 
@@ -852,7 +852,7 @@ class AccountSettingsPage extends React.Component {
     } = this.props;
 
     return (
-      <div className="page__account-settings container-fluid py-5">
+      <Container className="page__account-settings py-5" size="xl">
         {this.renderDuplicateTpaProviderMessage()}
         <h1 className="mb-4">
           {this.props.intl.formatMessage(messages['account.settings.page.heading'])}
@@ -869,7 +869,7 @@ class AccountSettingsPage extends React.Component {
             </div>
           </div>
         </div>
-      </div>
+      </Container>
     );
   }
 }


### PR DESCRIPTION
### Description

By default, this MFE does not restrict the max-width of its main content area, resulting in reduced readability due to longer lines of text, especially on wider screens. Most MFEs constrain containers with a max-width for this reason.

#### Local (elm-theme, Paragon v23)

Replaces hardcoded `.container-fluid` with `<Container size="xl">` to ensure the main content area does not stretch the full viewport.

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/dca6c7f7-370e-4999-96ad-2e134859f57b" />

#### Stage (elm-theme, Paragon v23)

No max-width, resulting in the main content area expanding full-width which is not ideal for readability (line length) and larger screens.

<img width="1509" alt="image" src="https://github.com/user-attachments/assets/393f95f1-dc96-4b36-ad7f-0f1ace10587e" />

#### Prod (brand-edx.org, Paragon v22)

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/670b5c75-f093-44d7-b530-f195624036cb" />

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.