### PR TITLE
feat: integrated notification preferences v2 API

### DIFF
--- a/.env
+++ b/.env
@@ -37,3 +37,4 @@ SUPPORT_URL_TO_UNLINK_SOCIAL_MEDIA_ACCOUNT='https://help.edx.org/edxlearner/s/ar
 COUNTRIES_WITH_DELETE_ACCOUNT_DISABLED='[]'
 # Fallback in local style files
 PARAGON_THEME_URLS={}
+ENABLE_PREFERENCES_V2='false'

--- a/.env.development
+++ b/.env.development
@@ -38,3 +38,4 @@ SUPPORT_URL_TO_UNLINK_SOCIAL_MEDIA_ACCOUNT='https://help.edx.org/edxlearner/s/ar
 COUNTRIES_WITH_DELETE_ACCOUNT_DISABLED='[]'
 # Fallback in local style files
 PARAGON_THEME_URLS={}
+ENABLE_PREFERENCES_V2='false'

--- a/.env.test
+++ b/.env.test
@@ -34,3 +34,4 @@ LEARNER_FEEDBACK_URL=''
 SUPPORT_URL_TO_UNLINK_SOCIAL_MEDIA_ACCOUNT='https://help.edx.org/edxlearner/s/article/How-do-I-link-or-unlink-my-edX-account-to-a-social-media-account'
 COUNTRIES_WITH_DELETE_ACCOUNT_DISABLED='[]'
 PARAGON_THEME_URLS={}
+ENABLE_PREFERENCES_V2='false'

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -74,6 +74,7 @@ initialize({
         MARKETING_EMAILS_OPT_IN: (process.env.MARKETING_EMAILS_OPT_IN || false),
         PASSWORD_RESET_SUPPORT_LINK: process.env.PASSWORD_RESET_SUPPORT_LINK,
         LEARNER_FEEDBACK_URL: process.env.LEARNER_FEEDBACK_URL,
+        ENABLE_PREFERENCES_V2: process.env.ENABLE_PREFERENCES_V2 || false,
       }, 'App loadConfig override handler');
     },
   },

--- a/src/notification-preferences/data/service.js
+++ b/src/notification-preferences/data/service.js
@@ -3,7 +3,10 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import snakeCase from 'lodash.snakecase';
 
 export const getCourseNotificationPreferences = async (courseId) => {
-  const url = `${getConfig().LMS_BASE_URL}/api/notifications/configurations/${courseId}`;
+  let url = `${getConfig().LMS_BASE_URL}/api/notifications/configurations/${courseId}`;
+  if (getConfig().ENABLE_PREFERENCES_V2 === 'true') {
+    url = `${getConfig().LMS_BASE_URL}/api/notifications/v2/configurations/`;
+  }
   const { data } = await getAuthenticatedHttpClient().get(url);
   return data;
 };
@@ -47,6 +50,12 @@ export const postPreferenceToggle = async (
     value,
     emailCadence,
   });
+  if (getConfig().ENABLE_PREFERENCES_V2 === 'true') {
+    const url = `${getConfig().LMS_BASE_URL}/api/notifications/v2/configurations/`;
+    const { data } = await getAuthenticatedHttpClient().put(url, patchData);
+    return data;
+  }
+
   const url = `${getConfig().LMS_BASE_URL}/api/notifications/preferences/update-all/`;
   const { data } = await getAuthenticatedHttpClient().post(url, patchData);
   return data;


### PR DESCRIPTION
## Desctiption 

This pull request introduces a feature flag (`ENABLE_PREFERENCES_V2`) to enable or disable the use of a new version of the notification preferences API (`v2`). The changes include updates to configuration files, the application initialization process, and service methods for handling notification preferences.

### Configuration Updates:
* `.env`, `.env.development`, `.env.test`: Added the `ENABLE_PREFERENCES_V2` feature flag to control the usage of the new notification preferences API.


### Notification Preferences Service Updates:
* `src/notification-preferences/data/service.js`:
  - Modified `getCourseNotificationPreferences` to use the `v2` API endpoint if the `ENABLE_PREFERENCES_V2` flag is enabled.
  - Updated `postPreferenceToggle` to conditionally use the `v2` API endpoint for updating notification preferences when the feature flag is active.

## Ticket 
https://2u-internal.atlassian.net/browse/INF-2001