### PR TITLE
Replace of injectIntl with useIntl() 1/10

### DIFF
--- a/src/account-settings/certificate-preference/CertificatePreference.jsx
+++ b/src/account-settings/certificate-preference/CertificatePreference.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 
@@ -8,7 +8,7 @@ import {
   ModalDialog,
   StatefulButton,
 } from '@openedx/paragon';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 
 import {
   closeForm,
@@ -22,7 +22,6 @@ import commonMessages from '../AccountSettingsPage.messages';
 import messages from './messages';
 
 const CertificatePreference = ({
-  intl,
   fieldName,
   originalFullName,
   originalVerifiedName,
@@ -33,6 +32,7 @@ const CertificatePreference = ({
   const [checked, setChecked] = useState(false);
   const [modalIsOpen, setModalIsOpen] = useState(false);
   const formId = 'useVerifiedNameForCerts';
+  const intl = useIntl();
 
   const handleCheckboxChange = () => {
     if (!checked) {
@@ -155,7 +155,6 @@ const CertificatePreference = ({
 };
 
 CertificatePreference.propTypes = {
-  intl: intlShape.isRequired,
   fieldName: PropTypes.string.isRequired,
   originalFullName: PropTypes.string,
   originalVerifiedName: PropTypes.string,
@@ -170,4 +169,4 @@ CertificatePreference.defaultProps = {
   useVerifiedNameForCerts: false,
 };
 
-export default connect(certPreferenceSelector)(injectIntl(CertificatePreference));
+export default connect(certPreferenceSelector)(CertificatePreference);

--- a/src/account-settings/certificate-preference/test/CertificatePreference.test.jsx
+++ b/src/account-settings/certificate-preference/test/CertificatePreference.test.jsx
@@ -10,7 +10,7 @@ import {
 } from '@testing-library/react';
 
 import * as auth from '@edx/frontend-platform/auth';
-import { IntlProvider, injectIntl } from '@edx/frontend-platform/i18n';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
 import messages from '../messages';
 
 // Modal creates a portal.  Overriding createPortal allows portals to be tested in jest.
@@ -29,8 +29,6 @@ jest.mock('react-redux', () => ({
 
 jest.mock('@edx/frontend-platform/auth');
 jest.mock('../../data/selectors', () => jest.fn().mockImplementation(() => ({ certPreferenceSelector: () => ({}) })));
-
-const IntlCertificatePreference = injectIntl(CertificatePreference);
 
 const mockStore = configureStore();
 
@@ -57,7 +55,6 @@ describe('NameChange', () => {
       originalVerifiedName: 'edX Verified',
       saveState: null,
       useVerifiedNameForCerts: false,
-      intl: {},
     };
 
     auth.getAuthenticatedHttpClient = jest.fn(() => ({
@@ -77,7 +74,7 @@ describe('NameChange', () => {
       originalVerifiedName: '',
     };
 
-    const wrapper = render(reduxWrapper(<IntlCertificatePreference {...props} />));
+    const wrapper = render(reduxWrapper(<CertificatePreference {...props} />));
 
     expect(wrapper).toMatchSnapshot();
   });
@@ -88,7 +85,7 @@ describe('NameChange', () => {
       useVerifiedNameForCerts: true,
     };
 
-    render(reduxWrapper(<IntlCertificatePreference {...props} />));
+    render(reduxWrapper(<CertificatePreference {...props} />));
 
     const checkbox = screen.getByLabelText(labelText);
     expect(checkbox.checked).toEqual(false);
@@ -103,7 +100,7 @@ describe('NameChange', () => {
   });
 
   it('triggers modal when attempting to uncheck checkbox', () => {
-    render(reduxWrapper(<IntlCertificatePreference {...props} />));
+    render(reduxWrapper(<CertificatePreference {...props} />));
 
     const checkbox = screen.getByLabelText(labelText);
     expect(checkbox.checked).toEqual(true);
@@ -115,7 +112,7 @@ describe('NameChange', () => {
   });
 
   it('updates draft when changing radio value', () => {
-    render(reduxWrapper(<IntlCertificatePreference {...props} />));
+    render(reduxWrapper(<CertificatePreference {...props} />));
 
     const checkbox = screen.getByLabelText(labelText);
     fireEvent.click(checkbox);
@@ -133,7 +130,7 @@ describe('NameChange', () => {
   });
 
   it('clears draft on cancel', () => {
-    render(reduxWrapper(<IntlCertificatePreference {...props} />));
+    render(reduxWrapper(<CertificatePreference {...props} />));
 
     const checkbox = screen.getByLabelText(labelText);
     fireEvent.click(checkbox);
@@ -146,7 +143,7 @@ describe('NameChange', () => {
   });
 
   it('submits', () => {
-    render(reduxWrapper(<IntlCertificatePreference {...props} />));
+    render(reduxWrapper(<CertificatePreference {...props} />));
 
     const checkbox = screen.getByLabelText(labelText);
     fireEvent.click(checkbox);
@@ -166,7 +163,7 @@ describe('NameChange', () => {
       useVerifiedNameForCerts: true,
     };
 
-    render(reduxWrapper(<IntlCertificatePreference {...props} />));
+    render(reduxWrapper(<CertificatePreference {...props} />));
 
     const checkbox = screen.getByLabelText(labelText);
     expect(checkbox.checked).toEqual(true);

--- a/src/account-settings/delete-account/BeforeProceedingBanner.jsx
+++ b/src/account-settings/delete-account/BeforeProceedingBanner.jsx
@@ -1,6 +1,5 @@
-import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage, injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Hyperlink } from '@openedx/paragon';
@@ -13,7 +12,8 @@ import messages from './messages';
 import Alert from '../Alert';
 
 const BeforeProceedingBanner = (props) => {
-  const { instructionMessageId, intl, supportArticleUrl } = props;
+  const { instructionMessageId, supportArticleUrl } = props;
+  const intl = useIntl();
 
   return (
     <Alert
@@ -41,8 +41,7 @@ const BeforeProceedingBanner = (props) => {
 
 BeforeProceedingBanner.propTypes = {
   instructionMessageId: PropTypes.string.isRequired,
-  intl: intlShape.isRequired,
   supportArticleUrl: PropTypes.string.isRequired,
 };
 
-export default injectIntl(BeforeProceedingBanner);
+export default BeforeProceedingBanner;

--- a/src/account-settings/delete-account/BeforeProceedingBanner.test.jsx
+++ b/src/account-settings/delete-account/BeforeProceedingBanner.test.jsx
@@ -1,6 +1,5 @@
-import React from 'react';
 import renderer from 'react-test-renderer';
-import { IntlProvider, injectIntl, createIntl } from '@edx/frontend-platform/i18n';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
 
 jest.mock('react-dom', () => ({
   ...jest.requireActual('react-dom'),
@@ -9,19 +8,16 @@ jest.mock('react-dom', () => ({
 
 import BeforeProceedingBanner from './BeforeProceedingBanner'; // eslint-disable-line import/first
 
-const IntlBeforeProceedingBanner = injectIntl(BeforeProceedingBanner);
-
 describe('BeforeProceedingBanner', () => {
   it('should match the snapshot if SUPPORT_URL_TO_UNLINK_SOCIAL_MEDIA_ACCOUNT does not have a support link', () => {
     const props = {
       instructionMessageId: 'account.settings.delete.account.please.unlink',
-      intl: createIntl({ locale: 'en' }),
       supportArticleUrl: '',
     };
     const tree = renderer
       .create((
         <IntlProvider locale="en">
-          <IntlBeforeProceedingBanner
+          <BeforeProceedingBanner
             {...props}
           />
         </IntlProvider>
@@ -33,13 +29,12 @@ describe('BeforeProceedingBanner', () => {
   it('should match the snapshot when SUPPORT_URL_TO_UNLINK_SOCIAL_MEDIA_ACCOUNT has a support link', () => {
     const props = {
       instructionMessageId: 'account.settings.delete.account.please.unlink',
-      intl: createIntl({ locale: 'en' }),
       supportArticleUrl: 'http://test-support.edx',
     };
     const tree = renderer
       .create((
         <IntlProvider locale="en">
-          <IntlBeforeProceedingBanner
+          <BeforeProceedingBanner
             {...props}
           />
         </IntlProvider>

--- a/src/id-verification/IdVerificationPage.jsx
+++ b/src/id-verification/IdVerificationPage.jsx
@@ -1,11 +1,11 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 import {
   Route, Routes, useLocation, useNavigate,
 } from 'react-router-dom';
 import camelCase from 'lodash.camelcase';
 import qs from 'qs';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import { Button, ModalDialog, ActionRow } from '@openedx/paragon';
 import { getConfig } from '@edx/frontend-platform';
 import { idVerificationSelector } from './data/selectors';
@@ -26,9 +26,10 @@ import SubmittedPanel from './panels/SubmittedPanel';
 import messages from './IdVerification.messages';
 
 // eslint-disable-next-line react/prefer-stateless-function
-const IdVerificationPage = (props) => {
+const IdVerificationPage = () => {
   const { search } = useLocation();
   const navigate = useNavigate();
+  const intl = useIntl();
 
   const [isModalOpen, setIsModalOpen] = useState(false);
 
@@ -78,33 +79,33 @@ const IdVerificationPage = (props) => {
       </div>
       <ModalDialog
         isOpen={isModalOpen}
-        title={props.intl.formatMessage(messages['id.verification.privacy.title'])}
+        title={intl.formatMessage(messages['id.verification.privacy.title'])}
         onClose={() => setIsModalOpen(false)}
         size="lg"
         hasCloseButton={false}
       >
         <ModalDialog.Header>
           <ModalDialog.Title data-testid="Id-modal">
-            {props.intl.formatMessage(messages['id.verification.privacy.title'])}
+            {intl.formatMessage(messages['id.verification.privacy.title'])}
           </ModalDialog.Title>
         </ModalDialog.Header>
         <ModalDialog.Body>
           <div className="p-3">
             <h6>
-              {props.intl.formatMessage(
+              {intl.formatMessage(
                 messages['id.verification.privacy.need.photo.question'],
                 { siteName: getConfig().SITE_NAME },
               )}
             </h6>
-            <p>{props.intl.formatMessage(messages['id.verification.privacy.need.photo.answer'])}</p>
+            <p>{intl.formatMessage(messages['id.verification.privacy.need.photo.answer'])}</p>
             <h6>
-              {props.intl.formatMessage(
+              {intl.formatMessage(
                 messages['id.verification.privacy.do.with.photo.question'],
                 { siteName: getConfig().SITE_NAME },
               )}
             </h6>
             <p>
-              {props.intl.formatMessage(
+              {intl.formatMessage(
                 messages['id.verification.privacy.do.with.photo.answer'],
                 { siteName: getConfig().SITE_NAME },
               )}
@@ -114,7 +115,7 @@ const IdVerificationPage = (props) => {
         <ModalDialog.Footer className="p-2">
           <ActionRow>
             <ModalDialog.CloseButton variant="link">
-              {props.intl.formatMessage(messages['id.verification.privacy.modal.close.button'])}
+              {intl.formatMessage(messages['id.verification.privacy.modal.close.button'])}
             </ModalDialog.CloseButton>
           </ActionRow>
         </ModalDialog.Footer>
@@ -124,8 +125,4 @@ const IdVerificationPage = (props) => {
   );
 };
 
-IdVerificationPage.propTypes = {
-  intl: intlShape.isRequired,
-};
-
-export default connect(idVerificationSelector, {})(injectIntl(IdVerificationPage));
+export default connect(idVerificationSelector, {})(IdVerificationPage);

--- a/src/id-verification/tests/IdVerificationPage.test.jsx
+++ b/src/id-verification/tests/IdVerificationPage.test.jsx
@@ -1,12 +1,11 @@
 /* eslint-disable react/jsx-no-useless-fragment */
-import React from 'react';
 import { Provider } from 'react-redux';
 import { MemoryRouter as Router } from 'react-router-dom';
 import configureStore from 'redux-mock-store';
 import {
   render, act, screen, fireEvent,
 } from '@testing-library/react';
-import { IntlProvider, injectIntl } from '@edx/frontend-platform/i18n';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
 import IdVerificationPageSlot from '../../plugin-slots/IdVerificationPageSlot';
 import * as selectors from '../data/selectors';
 
@@ -47,22 +46,18 @@ jest.mock('../panels/SubmittedPanel', () => function SubmittedPanelMock() {
   return <></>;
 });
 
-const IntlIdVerificationPage = injectIntl(IdVerificationPageSlot);
 const mockStore = configureStore();
 
 describe('IdVerificationPage', () => {
   selectors.mockClear();
   jest.spyOn(Storage.prototype, 'setItem');
   const store = mockStore();
-  const props = {
-    intl: {},
-  };
   it('decodes and stores course_id', async () => {
     await act(async () => render((
       <Router initialEntries={[`/?course_id=${encodeURIComponent('course-v1:edX+DemoX+Demo_Course')}`]}>
         <IntlProvider locale="en">
           <Provider store={store}>
-            <IntlIdVerificationPage {...props} />
+            <IdVerificationPageSlot />
           </Provider>
         </IntlProvider>
       </Router>
@@ -78,7 +73,7 @@ describe('IdVerificationPage', () => {
       <Router initialEntries={['/?next=dashboard']}>
         <IntlProvider locale="en">
           <Provider store={store}>
-            <IntlIdVerificationPage {...props} />
+            <IdVerificationPageSlot />
           </Provider>
         </IntlProvider>
       </Router>
@@ -93,7 +88,7 @@ describe('IdVerificationPage', () => {
       <Router initialEntries={['/?next=dashboard']}>
         <IntlProvider locale="en">
           <Provider store={store}>
-            <IntlIdVerificationPage {...props} />
+            <IdVerificationPageSlot />
           </Provider>
         </IntlProvider>
       </Router>
@@ -107,7 +102,7 @@ describe('IdVerificationPage', () => {
       <Router initialEntries={['/?next=dashboard']}>
         <IntlProvider locale="en">
           <Provider store={store}>
-            <IntlIdVerificationPage {...props} />
+            <IdVerificationPageSlot />
           </Provider>
         </IntlProvider>
       </Router>


### PR DESCRIPTION
### Description
Replace all usages of the deprecated injectIntl HOC with the useIntl() hook from @edx/frontend-platform/i18n.

Files to refactor:

- src/account-settings/certificate-preference/test/CertificatePreference.test.jsx
- src/account-settings/certificate-preference/CertificatePreference.jsx
- src/account-settings/delete-account/BeforeProceedingBanner.jsx
- src/account-settings/delete-account/BeforeProceedingBanner.test.jsx
- src/id-verification/IdVerificationPage.jsx
- src/id-verification/tests/IdVerificationPage.test.jsx 

#### Support Information
Closes #1286 