### PR TITLE
Replace of injectIntl with useIntl() 3/10

### DIFF
--- a/src/account-settings/EditableField.jsx
+++ b/src/account-settings/EditableField.jsx
@@ -1,8 +1,7 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import {
   Button, Form, StatefulButton,
 } from '@openedx/paragon';
@@ -39,10 +38,10 @@ const EditableField = (props) => {
     isEditing,
     isEditable,
     isGrayedOut,
-    intl,
     ...others
   } = props;
   const id = `field-${name}`;
+  const intl = useIntl();
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -188,7 +187,6 @@ EditableField.propTypes = {
   isEditing: PropTypes.bool,
   isEditable: PropTypes.bool,
   isGrayedOut: PropTypes.bool,
-  intl: intlShape.isRequired,
 };
 
 EditableField.defaultProps = {
@@ -209,4 +207,4 @@ EditableField.defaultProps = {
 export default connect(editableFieldSelector, {
   onEdit: openForm,
   onCancel: closeForm,
-})(injectIntl(EditableField));
+})(EditableField);

--- a/src/account-settings/EmailField.jsx
+++ b/src/account-settings/EmailField.jsx
@@ -1,7 +1,6 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { injectIntl, intlShape, FormattedMessage } from '@edx/frontend-platform/i18n';
+import { useIntl, FormattedMessage } from '@edx/frontend-platform/i18n';
 import {
   Button, StatefulButton, Form,
 } from '@openedx/paragon';
@@ -35,9 +34,9 @@ const EmailField = (props) => {
     onChange,
     isEditing,
     isEditable,
-    intl,
   } = props;
   const id = `field-${name}`;
+  const intl = useIntl();
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -191,7 +190,6 @@ EmailField.propTypes = {
   onChange: PropTypes.func.isRequired,
   isEditing: PropTypes.bool,
   isEditable: PropTypes.bool,
-  intl: intlShape.isRequired,
 };
 
 EmailField.defaultProps = {
@@ -210,4 +208,4 @@ EmailField.defaultProps = {
 export default connect(editableFieldSelector, {
   onEdit: openForm,
   onCancel: closeForm,
-})(injectIntl(EmailField));
+})(EmailField);

--- a/src/id-verification/panels/GetNameIdPanel.jsx
+++ b/src/id-verification/panels/GetNameIdPanel.jsx
@@ -1,9 +1,9 @@
-import React, {
+import {
   useContext, useEffect, useRef,
 } from 'react';
 import { Form } from '@openedx/paragon';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 
 import { useNextPanelSlug } from '../routing-utilities';
 import BasePanel from './BasePanel';
@@ -11,12 +11,13 @@ import IdVerificationContext from '../IdVerificationContext';
 
 import messages from '../IdVerification.messages';
 
-const GetNameIdPanel = (props) => {
+const GetNameIdPanel = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const nameInputRef = useRef();
   const panelSlug = 'get-name-id';
   const nextPanelSlug = useNextPanelSlug(panelSlug);
+  const intl = useIntl();
 
   const { nameOnAccount, idPhotoName, setIdPhotoName } = useContext(IdVerificationContext);
   const nameOnAccountValue = nameOnAccount || '';
@@ -41,19 +42,19 @@ const GetNameIdPanel = (props) => {
   return (
     <BasePanel
       name={panelSlug}
-      title={props.intl.formatMessage(messages['id.verification.name.check.title'])}
+      title={intl.formatMessage(messages['id.verification.name.check.title'])}
     >
       <p>
-        {props.intl.formatMessage(messages['id.verification.name.check.instructions'])}
+        {intl.formatMessage(messages['id.verification.name.check.instructions'])}
       </p>
       <p>
-        {props.intl.formatMessage(messages['id.verification.name.check.mismatch.information'])}
+        {intl.formatMessage(messages['id.verification.name.check.mismatch.information'])}
       </p>
 
       <Form onSubmit={handleSubmit}>
         <Form.Group>
           <Form.Label className="font-weight-bold" htmlFor="photo-id-name">
-            {props.intl.formatMessage(messages['id.verification.name.label'])}
+            {intl.formatMessage(messages['id.verification.name.label'])}
           </Form.Label>
           <Form.Control
             controlId="photo-id-name"
@@ -72,7 +73,7 @@ const GetNameIdPanel = (props) => {
               data-testid="id-name-feedback-message"
               type="invalid"
             >
-              {props.intl.formatMessage(messages['id.verification.name.error'])}
+              {intl.formatMessage(messages['id.verification.name.error'])}
             </Form.Control.Feedback>
           )}
         </Form.Group>
@@ -85,15 +86,11 @@ const GetNameIdPanel = (props) => {
           data-testid="next-button"
           aria-disabled={!idPhotoName}
         >
-          {props.intl.formatMessage(messages['id.verification.next'])}
+          {intl.formatMessage(messages['id.verification.next'])}
         </Link>
       </div>
     </BasePanel>
   );
 };
 
-GetNameIdPanel.propTypes = {
-  intl: intlShape.isRequired,
-};
-
-export default injectIntl(GetNameIdPanel);
+export default GetNameIdPanel;

--- a/src/id-verification/panels/IdContextPanel.jsx
+++ b/src/id-verification/panels/IdContextPanel.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 
 import { useNextPanelSlug } from '../routing-utilities';
 import BasePanel from './BasePanel';
@@ -8,49 +8,46 @@ import CameraHelp from '../CameraHelp';
 import messages from '../IdVerification.messages';
 import exampleCard from '../assets/example-card.png';
 
-const IdContextPanel = (props) => {
+const IdContextPanel = () => {
   const panelSlug = 'id-context';
   const nextPanelSlug = useNextPanelSlug(panelSlug);
+  const intl = useIntl();
   return (
     <BasePanel
       name={panelSlug}
-      title={props.intl.formatMessage(messages['id.verification.id.tips.title'])}
+      title={intl.formatMessage(messages['id.verification.id.tips.title'])}
     >
-      <p>{props.intl.formatMessage(messages['id.verification.id.tips.description'])}</p>
+      <p>{intl.formatMessage(messages['id.verification.id.tips.description'])}</p>
       <div className="card mb-4 shadow accent border-warning">
         <div className="card-body">
           <h6>
-            {props.intl.formatMessage(messages['id.verification.photo.tips.list.title'])}
+            {intl.formatMessage(messages['id.verification.photo.tips.list.title'])}
           </h6>
           <p>
-            {props.intl.formatMessage(messages['id.verification.photo.tips.list.description'])}
+            {intl.formatMessage(messages['id.verification.photo.tips.list.description'])}
           </p>
           <ul>
             <li>
-              {props.intl.formatMessage(messages['id.verification.id.tips.list.well.lit'])}
+              {intl.formatMessage(messages['id.verification.id.tips.list.well.lit'])}
             </li>
             <li>
-              {props.intl.formatMessage(messages['id.verification.id.tips.list.clear'])}
+              {intl.formatMessage(messages['id.verification.id.tips.list.clear'])}
             </li>
           </ul>
           <img
             src={exampleCard}
-            alt={props.intl.formatMessage(messages['id.verification.example.card.alt'])}
+            alt={intl.formatMessage(messages['id.verification.example.card.alt'])}
           />
         </div>
       </div>
       <CameraHelp isOpen />
       <div className="action-row">
         <Link to={`/id-verification/${nextPanelSlug}`} className="btn btn-primary" data-testid="next-button">
-          {props.intl.formatMessage(messages['id.verification.next'])}
+          {intl.formatMessage(messages['id.verification.next'])}
         </Link>
       </div>
     </BasePanel>
   );
 };
 
-IdContextPanel.propTypes = {
-  intl: intlShape.isRequired,
-};
-
-export default injectIntl(IdContextPanel);
+export default IdContextPanel;

--- a/src/id-verification/tests/panels/GetNameIdPanel.test.jsx
+++ b/src/id-verification/tests/panels/GetNameIdPanel.test.jsx
@@ -1,10 +1,9 @@
-import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import {
   render, cleanup, act, screen, fireEvent,
 } from '@testing-library/react';
 import '@edx/frontend-platform/analytics';
-import { injectIntl, IntlProvider } from '@edx/frontend-platform/i18n';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
 import IdVerificationContext from '../../IdVerificationContext';
 import { VerifiedNameContext } from '../../VerifiedNameContext';
 import GetNameIdPanel from '../../panels/GetNameIdPanel';
@@ -13,13 +12,7 @@ jest.mock('@edx/frontend-platform/analytics', () => ({
   sendTrackEvent: jest.fn(),
 }));
 
-const IntlGetNameIdPanel = injectIntl(GetNameIdPanel);
-
 describe('GetNameIdPanel', () => {
-  const defaultProps = {
-    intl: {},
-  };
-
   const IDVerificationContextValue = {
     nameOnAccount: 'test',
     userId: 3,
@@ -37,7 +30,7 @@ describe('GetNameIdPanel', () => {
         <IntlProvider locale="en">
           <VerifiedNameContext.Provider value={verifiedNameContextValue}>
             <IdVerificationContext.Provider value={idVerificationContextValue}>
-              <IntlGetNameIdPanel {...defaultProps} />
+              <GetNameIdPanel />
             </IdVerificationContext.Provider>
           </VerifiedNameContext.Provider>
         </IntlProvider>

--- a/src/id-verification/tests/panels/IdContextPanel.test.jsx
+++ b/src/id-verification/tests/panels/IdContextPanel.test.jsx
@@ -4,7 +4,7 @@ import {
   render, cleanup, act, screen, fireEvent,
 } from '@testing-library/react';
 import '@edx/frontend-platform/analytics';
-import { injectIntl, IntlProvider } from '@edx/frontend-platform/i18n';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
 import IdVerificationContext from '../../IdVerificationContext';
 import IdContextPanel from '../../panels/IdContextPanel';
 
@@ -12,13 +12,7 @@ jest.mock('@edx/frontend-platform/analytics', () => ({
   sendTrackEvent: jest.fn(),
 }));
 
-const IntlIdContextPanel = injectIntl(IdContextPanel);
-
 describe('IdContextPanel', () => {
-  const defaultProps = {
-    intl: {},
-  };
-
   const contextValue = {
     facePhotoFile: 'test.jpg',
     reachedSummary: false,
@@ -33,7 +27,7 @@ describe('IdContextPanel', () => {
       <Router>
         <IntlProvider locale="en">
           <IdVerificationContext.Provider value={contextValue}>
-            <IntlIdContextPanel {...defaultProps} />
+            <IdContextPanel />
           </IdVerificationContext.Provider>
         </IntlProvider>
       </Router>
@@ -49,7 +43,7 @@ describe('IdContextPanel', () => {
       <Router>
         <IntlProvider locale="en">
           <IdVerificationContext.Provider value={contextValue}>
-            <IntlIdContextPanel {...defaultProps} />
+            <IdContextPanel />
           </IdVerificationContext.Provider>
         </IntlProvider>
       </Router>


### PR DESCRIPTION
### Description
As part of the project for improvements as follow up of react-unit-test-utils, we are going to replace all usages of the deprecated `injectIntl` HOC with the `useIntl()` hook from @edx/frontend-platform/i18n. It is a very straight-forward change, in order to accomplish this we did the following changes:

- In components we have to remove the old `injectIntl`, remove intl as a prop and use the hook instead.
- In tests we need to stop using `injectIntl` and just use the desired component wrapped in a `IntlProvider` (from @edx/frontend-platform/i18n).

Files to refactor:

- src/account-settings/EditableField.jsx
- src/account-settings/EmailField.jsx
- src/id-verification/panels/GetNameIdPanel.jsx
- src/id-verification/tests/panels/GetNameIdPanel.test.jsx
- src/id-verification/panels/IdContextPanel.jsx
- src/id-verification/tests/panels/IdContextPanel.test.jsx

#### Support Information
Closes #1288 