### PR TITLE
Replace of injectIntl with useIntl() 5/10

### DIFF
--- a/src/id-verification/AccessBlocked.jsx
+++ b/src/id-verification/AccessBlocked.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { getConfig } from '@edx/frontend-platform';
-import { injectIntl, intlShape, FormattedMessage } from '@edx/frontend-platform/i18n';
+import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 
 import messages from './IdVerification.messages';
 import { ERROR_REASONS } from './IdVerificationContext';
 
-const AccessBlocked = ({ error, intl }) => {
+const AccessBlocked = ({ error }) => {
+  const intl = useIntl();
   const handleMessage = () => {
     if (error === ERROR_REASONS.COURSE_ENROLLMENT) {
       return <p>{intl.formatMessage(messages['id.verification.access.blocked.enrollment'])}</p>;
@@ -42,8 +43,7 @@ const AccessBlocked = ({ error, intl }) => {
 };
 
 AccessBlocked.propTypes = {
-  intl: intlShape.isRequired,
   error: PropTypes.string.isRequired,
 };
 
-export default injectIntl(AccessBlocked);
+export default AccessBlocked;

--- a/src/id-verification/CameraHelp.jsx
+++ b/src/id-verification/CameraHelp.jsx
@@ -1,41 +1,44 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Collapsible } from '@openedx/paragon';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 
 import { getConfig } from '@edx/frontend-platform';
 import messages from './IdVerification.messages';
 
-const CameraHelp = (props) => (
-  <div>
-    <Collapsible
-      styling="card"
-      title={props.intl.formatMessage(messages['id.verification.camera.help.sight.question'])}
-      className="mb-4 shadow"
-      defaultOpen={props.isOpen}
-    >
-      <p>
-        {props.intl.formatMessage(messages[`id.verification.camera.help.sight.answer.${props.isPortrait ? 'portrait' : 'id'}`])}
-      </p>
-    </Collapsible>
-    <Collapsible
-      styling="card"
-      title={props.intl.formatMessage(messages[`id.verification.camera.help.difficulty.question.${props.isPortrait ? 'portrait' : 'id'}`])}
-      className="mb-4 shadow"
-      defaultOpen={props.isOpen}
-    >
-      <p>
-        {props.intl.formatMessage(
-          messages['id.verification.camera.help.difficulty.answer'],
-          { siteName: getConfig().SITE_NAME },
-        )}
-      </p>
-    </Collapsible>
-  </div>
-);
+const CameraHelp = (props) => {
+  const intl = useIntl();
+
+  return (
+    <div>
+      <Collapsible
+        styling="card"
+        title={intl.formatMessage(messages['id.verification.camera.help.sight.question'])}
+        className="mb-4 shadow"
+        defaultOpen={props.isOpen}
+      >
+        <p>
+          {intl.formatMessage(messages[`id.verification.camera.help.sight.answer.${props.isPortrait ? 'portrait' : 'id'}`])}
+        </p>
+      </Collapsible>
+      <Collapsible
+        styling="card"
+        title={intl.formatMessage(messages[`id.verification.camera.help.difficulty.question.${props.isPortrait ? 'portrait' : 'id'}`])}
+        className="mb-4 shadow"
+        defaultOpen={props.isOpen}
+      >
+        <p>
+          {intl.formatMessage(
+            messages['id.verification.camera.help.difficulty.answer'],
+            { siteName: getConfig().SITE_NAME },
+          )}
+        </p>
+      </Collapsible>
+    </div>
+  );
+};
 
 CameraHelp.propTypes = {
-  intl: intlShape.isRequired,
   isOpen: PropTypes.bool,
   isPortrait: PropTypes.bool,
 };
@@ -45,4 +48,4 @@ CameraHelp.defaultProps = {
   isPortrait: false,
 };
 
-export default injectIntl(CameraHelp);
+export default CameraHelp;

--- a/src/id-verification/CameraHelpWithUpload.jsx
+++ b/src/id-verification/CameraHelpWithUpload.jsx
@@ -1,7 +1,7 @@
-import React, { useState, useContext } from 'react';
+import { useState, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Collapsible } from '@openedx/paragon';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 
 import messages from './IdVerification.messages';
@@ -11,6 +11,7 @@ import ImagePreview from './ImagePreview';
 import SupportedMediaTypes from './SupportedMediaTypes';
 
 const CameraHelpWithUpload = (props) => {
+  const intl = useIntl();
   const { setIdPhotoFile, idPhotoFile, userId } = useContext(IdVerificationContext);
   const [hasUploadedImage, setHasUploadedImage] = useState(false);
 
@@ -27,24 +28,23 @@ const CameraHelpWithUpload = (props) => {
     <div>
       <Collapsible
         styling="card"
-        title={props.intl.formatMessage(messages['id.verification.id.photo.unclear.question'])}
+        title={intl.formatMessage(messages['id.verification.id.photo.unclear.question'])}
         data-testid="collapsible"
         className="mb-4 shadow"
         defaultOpen={props.isOpen}
       >
-        {idPhotoFile && hasUploadedImage && <ImagePreview src={idPhotoFile} alt={props.intl.formatMessage(messages['id.verification.id.photo.preview.alt'])} />}
+        {idPhotoFile && hasUploadedImage && <ImagePreview src={idPhotoFile} alt={intl.formatMessage(messages['id.verification.id.photo.preview.alt'])} />}
         <p>
-          {props.intl.formatMessage(messages['id.verification.id.photo.instructions.upload'])}
+          {intl.formatMessage(messages['id.verification.id.photo.instructions.upload'])}
           <SupportedMediaTypes />
         </p>
-        <ImageFileUpload onFileChange={setAndTrackIdPhotoFile} intl={props.intl} />
+        <ImageFileUpload onFileChange={setAndTrackIdPhotoFile} />
       </Collapsible>
     </div>
   );
 };
 
 CameraHelpWithUpload.propTypes = {
-  intl: intlShape.isRequired,
   isOpen: PropTypes.bool,
 };
 
@@ -52,4 +52,4 @@ CameraHelpWithUpload.defaultProps = {
   isOpen: false,
 };
 
-export default injectIntl(CameraHelpWithUpload);
+export default CameraHelpWithUpload;

--- a/src/id-verification/ImageFileUpload.jsx
+++ b/src/id-verification/ImageFileUpload.jsx
@@ -1,11 +1,12 @@
-import React, { useCallback, useState } from 'react';
-import { intlShape } from '@edx/frontend-platform/i18n';
+import { useCallback, useState } from 'react';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import PropTypes from 'prop-types';
 import { Alert } from '@openedx/paragon';
 import messages from './IdVerification.messages';
 import SupportedMediaTypes from './SupportedMediaTypes';
 
-const ImageFileUpload = ({ onFileChange, intl }) => {
+const ImageFileUpload = ({ onFileChange }) => {
+  const intl = useIntl();
   const [error, setError] = useState(null);
   const errorTypes = {
     invalidFileType: 'invalidFileType',
@@ -58,7 +59,6 @@ const ImageFileUpload = ({ onFileChange, intl }) => {
 
 ImageFileUpload.propTypes = {
   onFileChange: PropTypes.func.isRequired,
-  intl: intlShape.isRequired,
 };
 
 export default ImageFileUpload;

--- a/src/id-verification/panels/RequestCameraAccessPanel.jsx
+++ b/src/id-verification/panels/RequestCameraAccessPanel.jsx
@@ -110,7 +110,7 @@ const RequestCameraAccessPanel = () => {
           <p data-testid="camera-unsupported-failure">
             {intl.formatMessage(messages['id.verification.camera.access.failure.unsupported'])}
           </p>
-          <UnsupportedCameraDirectionsPanel browserName={browserName} intl={intl} />
+          <UnsupportedCameraDirectionsPanel browserName={browserName} />
           <div className="action-row">
             {returnLink}
           </div>

--- a/src/id-verification/panels/SummaryPanel.jsx
+++ b/src/id-verification/panels/SummaryPanel.jsx
@@ -4,7 +4,7 @@ import {
   Alert, Hyperlink, Form, Button, Spinner,
 } from '@openedx/paragon';
 import { Link, useNavigate } from 'react-router-dom';
-import { injectIntl, intlShape, FormattedMessage } from '@edx/frontend-platform/i18n';
+import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 
 import { submitIdVerification } from '../data/service';
 import { useNextPanelSlug } from '../routing-utilities';
@@ -16,7 +16,8 @@ import messages from '../IdVerification.messages';
 import CameraHelpWithUpload from '../CameraHelpWithUpload';
 import SupportedMediaTypes from '../SupportedMediaTypes';
 
-const SummaryPanel = (props) => {
+const SummaryPanel = () => {
+  const intl = useIntl();
   const panelSlug = 'summary';
   const nextPanelSlug = useNextPanelSlug(panelSlug);
   const {
@@ -51,7 +52,7 @@ const SummaryPanel = (props) => {
             profileDataManager,
             support: (
               <Hyperlink destination={getConfig().SUPPORT_URL} target="_blank">
-                {props.intl.formatMessage(messages['id.verification.support'])}
+                {intl.formatMessage(messages['id.verification.support'])}
               </Hyperlink>
             ),
           }}
@@ -94,7 +95,7 @@ const SummaryPanel = (props) => {
         onClick={handleClick}
         data-testid="submit-button"
       >
-        {props.intl.formatMessage(messages['id.verification.review.confirm'])}
+        {intl.formatMessage(messages['id.verification.review.confirm'])}
       </Button>
     );
   };
@@ -102,18 +103,18 @@ const SummaryPanel = (props) => {
   function getError() {
     if (submissionError.status === 400) {
       if (submissionError.message.includes('face_image')) {
-        return props.intl.formatMessage(messages['id.verification.submission.alert.error.face']);
+        return intl.formatMessage(messages['id.verification.submission.alert.error.face']);
       }
       if (submissionError.message.includes('Photo ID image')) {
-        return props.intl.formatMessage(messages['id.verification.submission.alert.error.id']);
+        return intl.formatMessage(messages['id.verification.submission.alert.error.id']);
       }
       if (submissionError.message.includes('Name')) {
-        return props.intl.formatMessage(messages['id.verification.submission.alert.error.name']);
+        return intl.formatMessage(messages['id.verification.submission.alert.error.name']);
       }
       if (submissionError.message.includes('unsupported format')) {
         return (
           <>
-            {props.intl.formatMessage(messages['id.verification.submission.alert.error.unsupported'])}
+            {intl.formatMessage(messages['id.verification.submission.alert.error.unsupported'])}
             <SupportedMediaTypes />
           </>
         );
@@ -130,7 +131,7 @@ const SummaryPanel = (props) => {
         values={{
           support_link: (
             <Alert.Link href="https://support.edx.org/hc/en-us">
-              {props.intl.formatMessage(
+              {intl.formatMessage(
                 messages['id.verification.review.error'],
                 { siteName: getConfig().SITE_NAME },
               )}
@@ -144,7 +145,7 @@ const SummaryPanel = (props) => {
   return (
     <BasePanel
       name={panelSlug}
-      title={props.intl.formatMessage(messages['id.verification.review.title'])}
+      title={intl.formatMessage(messages['id.verification.review.title'])}
     >
       {submissionError && (
         <Alert
@@ -157,17 +158,17 @@ const SummaryPanel = (props) => {
         </Alert>
       )}
       <p>
-        {props.intl.formatMessage(messages['id.verification.review.description'])}
+        {intl.formatMessage(messages['id.verification.review.description'])}
       </p>
       <div className="row mb-4">
         <div className="col-6">
           <label htmlFor="photo-of-face" className="font-weight-bold">
-            {props.intl.formatMessage(messages['id.verification.review.portrait.label'])}
+            {intl.formatMessage(messages['id.verification.review.portrait.label'])}
           </label>
           <ImagePreview
             id="photo-of-face"
             src={facePhotoFile}
-            alt={props.intl.formatMessage(messages['id.verification.review.portrait.alt'])}
+            alt={intl.formatMessage(messages['id.verification.review.portrait.alt'])}
           />
           <Link
             className="btn btn-outline-primary"
@@ -175,17 +176,17 @@ const SummaryPanel = (props) => {
             state={{ fromSummary: true }}
             data-testid="portrait-retake"
           >
-            {props.intl.formatMessage(messages['id.verification.review.portrait.retake'])}
+            {intl.formatMessage(messages['id.verification.review.portrait.retake'])}
           </Link>
         </div>
         <div className="col-6">
           <label htmlFor="photo-of-id/edit" className="font-weight-bold">
-            {props.intl.formatMessage(messages['id.verification.review.id.label'])}
+            {intl.formatMessage(messages['id.verification.review.id.label'])}
           </label>
           <ImagePreview
             id="photo-of-id"
             src={idPhotoFile}
-            alt={props.intl.formatMessage(messages['id.verification.review.id.alt'])}
+            alt={intl.formatMessage(messages['id.verification.review.id.alt'])}
           />
           <Link
             className="btn btn-outline-primary"
@@ -193,14 +194,14 @@ const SummaryPanel = (props) => {
             state={{ fromSummary: true }}
             data-testid="id-retake"
           >
-            {props.intl.formatMessage(messages['id.verification.review.id.retake'])}
+            {intl.formatMessage(messages['id.verification.review.id.retake'])}
           </Link>
         </div>
       </div>
       <CameraHelpWithUpload />
       <div className="form-group">
         <label htmlFor="name-to-be-used" className="font-weight-bold">
-          {props.intl.formatMessage(messages['id.verification.name.label'])}
+          {intl.formatMessage(messages['id.verification.name.label'])}
         </label>
         {renderManagedProfileMessage()}
         <div className="d-flex">
@@ -236,8 +237,4 @@ const SummaryPanel = (props) => {
   );
 };
 
-SummaryPanel.propTypes = {
-  intl: intlShape.isRequired,
-};
-
-export default injectIntl(SummaryPanel);
+export default SummaryPanel;

--- a/src/id-verification/panels/TakeIdPhotoPanel.jsx
+++ b/src/id-verification/panels/TakeIdPhotoPanel.jsx
@@ -55,7 +55,7 @@ const TakeIdPhotoPanel = () => {
               {intl.formatMessage(messages['id.verification.id.photo.instructions.upload'])}
               <SupportedMediaTypes />
             </p>
-            <ImageFileUpload onFileChange={setIdPhotoFile} intl={intl} />
+            <ImageFileUpload onFileChange={setIdPhotoFile} />
           </div>
         )}
       </div>

--- a/src/id-verification/tests/AccessBlocked.test.jsx
+++ b/src/id-verification/tests/AccessBlocked.test.jsx
@@ -4,16 +4,13 @@ import {
   render, cleanup, act, screen,
 } from '@testing-library/react';
 import '@edx/frontend-platform/analytics';
-import { injectIntl, IntlProvider } from '@edx/frontend-platform/i18n';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
 
 import { ERROR_REASONS } from '../IdVerificationContext';
 import AccessBlocked from '../AccessBlocked';
 
-const IntlAccessBlocked = injectIntl(AccessBlocked);
-
 describe('AccessBlocked', () => {
   const defaultProps = {
-    intl: {},
     error: '',
   };
 
@@ -27,7 +24,7 @@ describe('AccessBlocked', () => {
     await act(async () => render((
       <Router>
         <IntlProvider locale="en">
-          <IntlAccessBlocked {...defaultProps} />
+          <AccessBlocked {...defaultProps} />
         </IntlProvider>
       </Router>
     )));
@@ -43,7 +40,7 @@ describe('AccessBlocked', () => {
     await act(async () => render((
       <Router>
         <IntlProvider locale="en">
-          <IntlAccessBlocked {...defaultProps} />
+          <AccessBlocked {...defaultProps} />
         </IntlProvider>
       </Router>
     )));
@@ -59,7 +56,7 @@ describe('AccessBlocked', () => {
     await act(async () => render((
       <Router>
         <IntlProvider locale="en">
-          <IntlAccessBlocked {...defaultProps} />
+          <AccessBlocked {...defaultProps} />
         </IntlProvider>
       </Router>
     )));

--- a/src/id-verification/tests/panels/SummaryPanel.test.jsx
+++ b/src/id-verification/tests/panels/SummaryPanel.test.jsx
@@ -1,11 +1,10 @@
 /* eslint-disable no-import-assign */
-import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import {
   render, cleanup, act, screen, fireEvent, waitFor,
 } from '@testing-library/react';
 import '@edx/frontend-platform/analytics';
-import { injectIntl, IntlProvider } from '@edx/frontend-platform/i18n';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
 import * as dataService from '../../data/service';
 import IdVerificationContext from '../../IdVerificationContext';
 import SummaryPanel from '../../panels/SummaryPanel';
@@ -18,13 +17,7 @@ jest.mock('@edx/frontend-platform/analytics', () => ({
 jest.mock('../../data/service');
 dataService.submitIdVerification = jest.fn().mockReturnValue({ success: true });
 
-const IntlSummaryPanel = injectIntl(SummaryPanel);
-
 describe('SummaryPanel', () => {
-  const defaultProps = {
-    intl: {},
-  };
-
   const appContextValue = {
     facePhotoFile: 'test.jpg',
     idPhotoFile: 'test.jpg',
@@ -42,7 +35,7 @@ describe('SummaryPanel', () => {
         <IntlProvider locale="en">
           <VerifiedNameContext.Provider value={verifiedNameContextValue}>
             <IdVerificationContext.Provider value={appContextValue}>
-              <IntlSummaryPanel {...defaultProps} />
+              <SummaryPanel />
             </IdVerificationContext.Provider>
           </VerifiedNameContext.Provider>
         </IntlProvider>


### PR DESCRIPTION
### Description
As part of the project for improvements as follow up of react-unit-test-utils, we are going to replace all usages of the deprecated `injectIntl` HOC with the `useIntl()` hook from @edx/frontend-platform/i18n. It is a very straight-forward change, in order to accomplish this we did the following changes:

- In components we have to remove the old `injectIntl`, remove intl as a prop and use the hook instead.
- In tests we need to stop using `injectIntl` and just use the desired component wrapped in a `IntlProvider` (from @edx/frontend-platform/i18n).

Files to refactor:
- src/id-verification/AccessBlocked.jsx
- src/id-verification/tests/AccessBlocked.test.jsx
- src/id-verification/CameraHelp.jsx
- src/id-verification/CameraHelpWithUpload.jsx
- src/id-verification/panels/SummaryPanel.jsx
- src/id-verification/tests/panels/SummaryPanel.test.jsx

#### Support Information
Closes #1290 
Closes #1285 