### PR TITLE
Replace of injectIntl with useIntl() 6/10

### DIFF
--- a/src/account-settings/delete-account/PrintingInstructions.jsx
+++ b/src/account-settings/delete-account/PrintingInstructions.jsx
@@ -1,11 +1,11 @@
-import React from 'react';
-import { FormattedMessage, injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 import { Hyperlink } from '@openedx/paragon';
 
 import { getConfig } from '@edx/frontend-platform';
 import messages from './messages';
 
-const PrintingInstructions = (props) => {
+const PrintingInstructions = () => {
+  const intl = useIntl();
   const actionLink = (
     <Hyperlink
       // TODO: What would a generic version of this link look like?  Should
@@ -13,7 +13,7 @@ const PrintingInstructions = (props) => {
       // We've removed the link from the default message.
       destination="https://help.edx.org/edxlearner/s/topic/0TOQq0000001UVVOA2/certificates"
     >
-      {props.intl.formatMessage(messages['account.settings.delete.account.text.3.link'])}
+      {intl.formatMessage(messages['account.settings.delete.account.text.3.link'])}
     </Hyperlink>
   );
 
@@ -40,8 +40,4 @@ const PrintingInstructions = (props) => {
   );
 };
 
-PrintingInstructions.propTypes = {
-  intl: intlShape.isRequired,
-};
-
-export default injectIntl(PrintingInstructions);
+export default PrintingInstructions;

--- a/src/account-settings/delete-account/SuccessModal.jsx
+++ b/src/account-settings/delete-account/SuccessModal.jsx
@@ -1,12 +1,12 @@
-import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import { ModalLayer, ModalCloseButton } from '@openedx/paragon';
 
 import messages from './messages';
 
 export const SuccessModal = (props) => {
-  const { status, intl, onClose } = props;
+  const intl = useIntl();
+  const { status, onClose } = props;
   return (
 
     <ModalLayer isOpen={status === 'deleted'} onClose={onClose}>
@@ -31,7 +31,6 @@ export const SuccessModal = (props) => {
 
 SuccessModal.propTypes = {
   status: PropTypes.oneOf(['confirming', 'pending', 'deleted', 'failed']),
-  intl: intlShape.isRequired,
   onClose: PropTypes.func.isRequired,
 };
 
@@ -39,4 +38,4 @@ SuccessModal.defaultProps = {
   status: null,
 };
 
-export default injectIntl(SuccessModal);
+export default SuccessModal;

--- a/src/account-settings/delete-account/SuccessModal.test.jsx
+++ b/src/account-settings/delete-account/SuccessModal.test.jsx
@@ -1,6 +1,5 @@
-import React from 'react';
 import renderer from 'react-test-renderer';
-import { IntlProvider, injectIntl } from '@edx/frontend-platform/i18n';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { waitFor } from '@testing-library/react';
 import { SuccessModal } from './SuccessModal';
 
@@ -9,8 +8,6 @@ jest.mock('react-dom', () => ({
   ...jest.requireActual('react-dom'),
   createPortal: jest.fn(node => node), // Mock portal behavior
 }));
-
-const IntlSuccessModal = injectIntl(SuccessModal);
 
 describe('SuccessModal', () => {
   let props = {};
@@ -25,22 +22,22 @@ describe('SuccessModal', () => {
   it('should match default closed success modal snapshot', async () => {
     await waitFor(() => {
       const tree = renderer.create((
-        <IntlProvider locale="en"><IntlSuccessModal {...props} /></IntlProvider>)).toJSON();
+        <IntlProvider locale="en"><SuccessModal {...props} /></IntlProvider>)).toJSON();
       expect(tree).toMatchSnapshot();
     });
     await waitFor(() => {
       const tree = renderer.create((
-        <IntlProvider locale="en"><IntlSuccessModal {...props} status="confirming" /></IntlProvider>)).toJSON();
+        <IntlProvider locale="en"><SuccessModal {...props} status="confirming" /></IntlProvider>)).toJSON();
       expect(tree).toMatchSnapshot();
     });
     await waitFor(() => {
       const tree = renderer.create((
-        <IntlProvider locale="en"><IntlSuccessModal {...props} status="pending" /></IntlProvider>)).toJSON();
+        <IntlProvider locale="en"><SuccessModal {...props} status="pending" /></IntlProvider>)).toJSON();
       expect(tree).toMatchSnapshot();
     });
     await waitFor(() => {
       const tree = renderer.create((
-        <IntlProvider locale="en"><IntlSuccessModal {...props} status="failed" /></IntlProvider>)).toJSON();
+        <IntlProvider locale="en"><SuccessModal {...props} status="failed" /></IntlProvider>)).toJSON();
       expect(tree).toMatchSnapshot();
     });
   });
@@ -49,7 +46,7 @@ describe('SuccessModal', () => {
     await waitFor(() => {
       const tree = renderer.create(
         <IntlProvider locale="en">
-          <IntlSuccessModal
+          <SuccessModal
             {...props}
             status="deleted"
           />

--- a/src/id-verification/panels/ReviewRequirementsPanel.jsx
+++ b/src/id-verification/panels/ReviewRequirementsPanel.jsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useContext } from 'react';
+import { useEffect, useContext } from 'react';
 import { Link } from 'react-router-dom';
 import { getConfig } from '@edx/frontend-platform';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
-import { injectIntl, intlShape, FormattedMessage } from '@edx/frontend-platform/i18n';
+import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 import { Alert, Hyperlink } from '@openedx/paragon';
 
 import { useNextPanelSlug } from '../routing-utilities';
@@ -12,7 +12,8 @@ import IdVerificationContext from '../IdVerificationContext';
 import messages from '../IdVerification.messages';
 import exampleCard from '../assets/example-card.png';
 
-const ReviewRequirementsPanel = (props) => {
+const ReviewRequirementsPanel = () => {
+  const intl = useIntl();
   const { userId, profileDataManager } = useContext(IdVerificationContext);
   const panelSlug = 'review-requirements';
   const nextPanelSlug = useNextPanelSlug(panelSlug);
@@ -41,7 +42,7 @@ const ReviewRequirementsPanel = (props) => {
               profileDataManager,
               support: (
                 <Hyperlink destination={getConfig().SUPPORT_URL} target="_blank">
-                  {props.intl.formatMessage(messages['id.verification.support'])}
+                  {intl.formatMessage(messages['id.verification.support'])}
                 </Hyperlink>
               ),
             }}
@@ -54,17 +55,17 @@ const ReviewRequirementsPanel = (props) => {
   return (
     <BasePanel
       name={panelSlug}
-      title={props.intl.formatMessage(messages['id.verification.requirements.title'])}
+      title={intl.formatMessage(messages['id.verification.requirements.title'])}
       focusOnMount={false}
     >
       {renderManagedProfileMessage()}
       <p>
-        {props.intl.formatMessage(messages['id.verification.requirements.description'])}
+        {intl.formatMessage(messages['id.verification.requirements.description'])}
       </p>
       <div className="card mb-4 shadow accent border-warning">
         <div className="card-body">
           <h6 aria-level="3">
-            {props.intl.formatMessage(messages['id.verification.requirements.card.device.title'])}
+            {intl.formatMessage(messages['id.verification.requirements.card.device.title'])}
           </h6>
           <p className="mb-0">
             <FormattedMessage
@@ -72,7 +73,7 @@ const ReviewRequirementsPanel = (props) => {
               defaultMessage="You need a device that has a camera. If you receive a browser prompt for access to your camera, please make sure to click {allow}."
               description="Text explaining that the user needs access to a camera."
               values={{
-                allow: <strong>{props.intl.formatMessage(messages['id.verification.requirements.card.device.allow'])}</strong>,
+                allow: <strong>{intl.formatMessage(messages['id.verification.requirements.card.device.allow'])}</strong>,
               }}
             />
           </p>
@@ -81,37 +82,37 @@ const ReviewRequirementsPanel = (props) => {
       <div className="card mb-4 shadow accent border-warning">
         <div className="card-body">
           <h6 aria-level="3">
-            {props.intl.formatMessage(messages['id.verification.requirements.card.id.title'])}
+            {intl.formatMessage(messages['id.verification.requirements.card.id.title'])}
           </h6>
           <p className="mb-0">
-            {props.intl.formatMessage(messages['id.verification.requirements.card.id.text'])}
+            {intl.formatMessage(messages['id.verification.requirements.card.id.text'])}
             <img
               src={exampleCard}
-              alt={props.intl.formatMessage(messages['id.verification.example.card.alt'])}
+              alt={intl.formatMessage(messages['id.verification.example.card.alt'])}
             />
           </p>
         </div>
       </div>
       <h4 aria-level="2" className="mb-3">
-        {props.intl.formatMessage(messages['id.verification.privacy.title'])}
+        {intl.formatMessage(messages['id.verification.privacy.title'])}
       </h4>
       <h6 aria-level="3">
-        {props.intl.formatMessage(
+        {intl.formatMessage(
           messages['id.verification.privacy.need.photo.question'],
           { siteName: getConfig().SITE_NAME },
         )}
       </h6>
       <p>
-        {props.intl.formatMessage(messages['id.verification.privacy.need.photo.answer'])}
+        {intl.formatMessage(messages['id.verification.privacy.need.photo.answer'])}
       </p>
       <h6 aria-level="3">
-        {props.intl.formatMessage(
+        {intl.formatMessage(
           messages['id.verification.privacy.do.with.photo.question'],
           { siteName: getConfig().SITE_NAME },
         )}
       </h6>
       <p>
-        {props.intl.formatMessage(
+        {intl.formatMessage(
           messages['id.verification.privacy.do.with.photo.answer'],
           { siteName: getConfig().SITE_NAME },
         )}
@@ -119,15 +120,11 @@ const ReviewRequirementsPanel = (props) => {
 
       <div className="action-row">
         <Link to={`/id-verification/${nextPanelSlug}`} className="btn btn-primary" data-testid="next-button">
-          {props.intl.formatMessage(messages['id.verification.next'])}
+          {intl.formatMessage(messages['id.verification.next'])}
         </Link>
       </div>
     </BasePanel>
   );
 };
 
-ReviewRequirementsPanel.propTypes = {
-  intl: intlShape.isRequired,
-};
-
-export default injectIntl(ReviewRequirementsPanel);
+export default ReviewRequirementsPanel;

--- a/src/id-verification/panels/UnsupportedCameraDirectionsPanel.jsx
+++ b/src/id-verification/panels/UnsupportedCameraDirectionsPanel.jsx
@@ -1,19 +1,21 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import messages from '../IdVerification.messages';
 
-export const UnsupportedCameraDirectionsPanel = (props) => (
-  <>
-    {props.browserName === 'Chrome' && <span>{props.intl.formatMessage(messages['id.verification.camera.access.failure.unsupported.chrome.explanation'])}</span>}
-    <span> </span>
-    <span>{props.intl.formatMessage(messages['id.verification.camera.access.failure.unsupported.instructions'])}</span>
-  </>
-);
+export const UnsupportedCameraDirectionsPanel = (props) => {
+  const intl = useIntl();
+  return (
+    <>
+      {props.browserName === 'Chrome' && <span>{intl.formatMessage(messages['id.verification.camera.access.failure.unsupported.chrome.explanation'])}</span>}
+      <span> </span>
+      <span>{intl.formatMessage(messages['id.verification.camera.access.failure.unsupported.instructions'])}</span>
+    </>
+  );
+};
 
 UnsupportedCameraDirectionsPanel.propTypes = {
-  intl: intlShape.isRequired,
   browserName: PropTypes.string.isRequired,
 };
 
-export default injectIntl(UnsupportedCameraDirectionsPanel);
+export default UnsupportedCameraDirectionsPanel;

--- a/src/id-verification/tests/panels/ReviewRequirementsPanel.test.jsx
+++ b/src/id-verification/tests/panels/ReviewRequirementsPanel.test.jsx
@@ -4,7 +4,7 @@ import {
   render, cleanup, act, screen, fireEvent,
 } from '@testing-library/react';
 import '@edx/frontend-platform/analytics';
-import { injectIntl, IntlProvider } from '@edx/frontend-platform/i18n';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
 import IdVerificationContext from '../../IdVerificationContext';
 import ReviewRequirementsPanel from '../../panels/ReviewRequirementsPanel';
 
@@ -12,13 +12,7 @@ jest.mock('@edx/frontend-platform/analytics', () => ({
   sendTrackEvent: jest.fn(),
 }));
 
-const IntlReviewRequirementsPanel = injectIntl(ReviewRequirementsPanel);
-
 describe('ReviewRequirementsPanel', () => {
-  const defaultProps = {
-    intl: {},
-  };
-
   const context = {};
 
   const getPanel = async () => {
@@ -26,7 +20,7 @@ describe('ReviewRequirementsPanel', () => {
       <Router>
         <IntlProvider locale="en">
           <IdVerificationContext.Provider value={context}>
-            <IntlReviewRequirementsPanel {...defaultProps} />
+            <ReviewRequirementsPanel />
           </IdVerificationContext.Provider>
         </IntlProvider>
       </Router>


### PR DESCRIPTION
### Description
Replace all usages of the deprecated injectIntl HOC with the useIntl() hook from @edx/frontend-platform/i18n.

Files to refactor:
- src/account-settings/delete-account/PrintingInstructions.jsx
- src/account-settings/delete-account/SuccessModal.jsx
- src/account-settings/delete-account/SuccessModal.test.jsx
- src/id-verification/panels/ReviewRequirementsPanel.jsx
- src/id-verification/tests/panels/ReviewRequirementsPanel.test.jsx
- src/id-verification/panels/UnsupportedCameraDirectionsPanel.jsx

#### Support Information
Closes #1291 