### PR TITLE
Replace of injectIntl with useIntl() 8/10

### DIFF
--- a/src/id-verification/panels/EnableCameraDirectionsPanel.jsx
+++ b/src/id-verification/panels/EnableCameraDirectionsPanel.jsx
@@ -1,17 +1,17 @@
 import PropTypes from 'prop-types';
-import React from 'react';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import messages from '../IdVerification.messages';
 
 export const EnableCameraDirectionsPanel = (props) => {
+  const intl = useIntl();
   if (props.browserName === 'Internet Explorer') {
     return (
       <>
-        <h6>{props.intl.formatMessage(messages['id.verification.camera.access.failure.temporary.ie11'])}</h6>
+        <h6>{intl.formatMessage(messages['id.verification.camera.access.failure.temporary.ie11'])}</h6>
         <ol>
-          <li>{props.intl.formatMessage(messages['id.verification.camera.access.failure.temporary.ie11.step1'])}</li>
-          <li>{props.intl.formatMessage(messages['id.verification.camera.access.failure.temporary.ie11.step2'])}</li>
-          <li>{props.intl.formatMessage(messages['id.verification.camera.access.failure.temporary.ie11.step3'])}</li>
+          <li>{intl.formatMessage(messages['id.verification.camera.access.failure.temporary.ie11.step1'])}</li>
+          <li>{intl.formatMessage(messages['id.verification.camera.access.failure.temporary.ie11.step2'])}</li>
+          <li>{intl.formatMessage(messages['id.verification.camera.access.failure.temporary.ie11.step3'])}</li>
         </ol>
       </>
     );
@@ -19,17 +19,17 @@ export const EnableCameraDirectionsPanel = (props) => {
   if (props.browserName === 'Chrome') {
     return (
       <>
-        <h6>{props.intl.formatMessage(messages['id.verification.camera.access.failure.temporary.chrome'])}</h6>
+        <h6>{intl.formatMessage(messages['id.verification.camera.access.failure.temporary.chrome'])}</h6>
         <ol>
-          <li>{props.intl.formatMessage(messages['id.verification.camera.access.failure.temporary.chrome.step1'])}</li>
-          <li>{props.intl.formatMessage(messages['id.verification.camera.access.failure.temporary.chrome.step2'])}</li>
+          <li>{intl.formatMessage(messages['id.verification.camera.access.failure.temporary.chrome.step1'])}</li>
+          <li>{intl.formatMessage(messages['id.verification.camera.access.failure.temporary.chrome.step2'])}</li>
           <ul>
-            <li>{props.intl.formatMessage(messages['id.verification.camera.access.failure.temporary.chrome.step2.windows'])}</li>
-            <li>{props.intl.formatMessage(messages['id.verification.camera.access.failure.temporary.chrome.step2.mac'])}</li>
+            <li>{intl.formatMessage(messages['id.verification.camera.access.failure.temporary.chrome.step2.windows'])}</li>
+            <li>{intl.formatMessage(messages['id.verification.camera.access.failure.temporary.chrome.step2.mac'])}</li>
           </ul>
-          <li>{props.intl.formatMessage(messages['id.verification.camera.access.failure.temporary.chrome.step3'])}</li>
-          <li>{props.intl.formatMessage(messages['id.verification.camera.access.failure.temporary.chrome.step4'])}</li>
-          <li>{props.intl.formatMessage(messages['id.verification.camera.access.failure.temporary.chrome.step5'])}</li>
+          <li>{intl.formatMessage(messages['id.verification.camera.access.failure.temporary.chrome.step3'])}</li>
+          <li>{intl.formatMessage(messages['id.verification.camera.access.failure.temporary.chrome.step4'])}</li>
+          <li>{intl.formatMessage(messages['id.verification.camera.access.failure.temporary.chrome.step5'])}</li>
         </ol>
       </>
     );
@@ -37,15 +37,15 @@ export const EnableCameraDirectionsPanel = (props) => {
   if (props.browserName === 'Firefox') {
     return (
       <>
-        <h6>{props.intl.formatMessage(messages['id.verification.camera.access.failure.temporary.firefox'])}</h6>
+        <h6>{intl.formatMessage(messages['id.verification.camera.access.failure.temporary.firefox'])}</h6>
         <ol>
-          <li>{props.intl.formatMessage(messages['id.verification.camera.access.failure.temporary.firefox.step1'])}</li>
-          <li>{props.intl.formatMessage(messages['id.verification.camera.access.failure.temporary.firefox.step2'])}</li>
-          <li>{props.intl.formatMessage(messages['id.verification.camera.access.failure.temporary.firefox.step3'])}</li>
-          <li>{props.intl.formatMessage(messages['id.verification.camera.access.failure.temporary.firefox.step4'])}</li>
-          <li>{props.intl.formatMessage(messages['id.verification.camera.access.failure.temporary.firefox.step5'])}</li>
-          <li>{props.intl.formatMessage(messages['id.verification.camera.access.failure.temporary.firefox.step6'])}</li>
-          <li>{props.intl.formatMessage(messages['id.verification.camera.access.failure.temporary.firefox.step7'])}</li>
+          <li>{intl.formatMessage(messages['id.verification.camera.access.failure.temporary.firefox.step1'])}</li>
+          <li>{intl.formatMessage(messages['id.verification.camera.access.failure.temporary.firefox.step2'])}</li>
+          <li>{intl.formatMessage(messages['id.verification.camera.access.failure.temporary.firefox.step3'])}</li>
+          <li>{intl.formatMessage(messages['id.verification.camera.access.failure.temporary.firefox.step4'])}</li>
+          <li>{intl.formatMessage(messages['id.verification.camera.access.failure.temporary.firefox.step5'])}</li>
+          <li>{intl.formatMessage(messages['id.verification.camera.access.failure.temporary.firefox.step6'])}</li>
+          <li>{intl.formatMessage(messages['id.verification.camera.access.failure.temporary.firefox.step7'])}</li>
         </ol>
       </>
     );
@@ -53,12 +53,12 @@ export const EnableCameraDirectionsPanel = (props) => {
   if (props.browserName === 'Safari') {
     return (
       <>
-        <h6>{props.intl.formatMessage(messages['id.verification.camera.access.failure.temporary.safari'])}</h6>
+        <h6>{intl.formatMessage(messages['id.verification.camera.access.failure.temporary.safari'])}</h6>
         <ol>
-          <li>{props.intl.formatMessage(messages['id.verification.camera.access.failure.temporary.safari.step1'])}</li>
-          <li>{props.intl.formatMessage(messages['id.verification.camera.access.failure.temporary.safari.step2'])}</li>
-          <li>{props.intl.formatMessage(messages['id.verification.camera.access.failure.temporary.safari.step3'])}</li>
-          <li>{props.intl.formatMessage(messages['id.verification.camera.access.failure.temporary.safari.step4'])}</li>
+          <li>{intl.formatMessage(messages['id.verification.camera.access.failure.temporary.safari.step1'])}</li>
+          <li>{intl.formatMessage(messages['id.verification.camera.access.failure.temporary.safari.step2'])}</li>
+          <li>{intl.formatMessage(messages['id.verification.camera.access.failure.temporary.safari.step3'])}</li>
+          <li>{intl.formatMessage(messages['id.verification.camera.access.failure.temporary.safari.step4'])}</li>
         </ol>
       </>
     );
@@ -68,8 +68,7 @@ export const EnableCameraDirectionsPanel = (props) => {
 };
 
 EnableCameraDirectionsPanel.propTypes = {
-  intl: intlShape.isRequired,
   browserName: PropTypes.string.isRequired,
 };
 
-export default injectIntl(EnableCameraDirectionsPanel);
+export default EnableCameraDirectionsPanel;

--- a/src/id-verification/panels/PortraitPhotoContextPanel.jsx
+++ b/src/id-verification/panels/PortraitPhotoContextPanel.jsx
@@ -1,37 +1,37 @@
-import React from 'react';
 import { Link } from 'react-router-dom';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 
 import { useNextPanelSlug } from '../routing-utilities';
 import BasePanel from './BasePanel';
 import CameraHelp from '../CameraHelp';
 import messages from '../IdVerification.messages';
 
-const PortraitPhotoContextPanel = (props) => {
+const PortraitPhotoContextPanel = () => {
+  const intl = useIntl();
   const panelSlug = 'portrait-photo-context';
   const nextPanelSlug = useNextPanelSlug(panelSlug);
   return (
     <BasePanel
       name={panelSlug}
-      title={props.intl.formatMessage(messages['id.verification.photo.tips.title'])}
+      title={intl.formatMessage(messages['id.verification.photo.tips.title'])}
     >
       <p>
-        {props.intl.formatMessage(messages['id.verification.photo.tips.description'])}
+        {intl.formatMessage(messages['id.verification.photo.tips.description'])}
       </p>
       <div className="card mb-4 shadow accent border-warning">
         <div className="card-body">
           <h6>
-            {props.intl.formatMessage(messages['id.verification.photo.tips.list.title'])}
+            {intl.formatMessage(messages['id.verification.photo.tips.list.title'])}
           </h6>
           <p>
-            {props.intl.formatMessage(messages['id.verification.photo.tips.list.description'])}
+            {intl.formatMessage(messages['id.verification.photo.tips.list.description'])}
           </p>
           <ul className="mb-0">
             <li>
-              {props.intl.formatMessage(messages['id.verification.photo.tips.list.well.lit'])}
+              {intl.formatMessage(messages['id.verification.photo.tips.list.well.lit'])}
             </li>
             <li>
-              {props.intl.formatMessage(messages['id.verification.photo.tips.list.inside.frame'])}
+              {intl.formatMessage(messages['id.verification.photo.tips.list.inside.frame'])}
             </li>
           </ul>
         </div>
@@ -39,15 +39,11 @@ const PortraitPhotoContextPanel = (props) => {
       <CameraHelp isOpen isPortrait />
       <div className="action-row">
         <Link to={`/id-verification/${nextPanelSlug}`} className="btn btn-primary" data-testid="next-button">
-          {props.intl.formatMessage(messages['id.verification.next'])}
+          {intl.formatMessage(messages['id.verification.next'])}
         </Link>
       </div>
     </BasePanel>
   );
 };
 
-PortraitPhotoContextPanel.propTypes = {
-  intl: intlShape.isRequired,
-};
-
-export default injectIntl(PortraitPhotoContextPanel);
+export default PortraitPhotoContextPanel;

--- a/src/id-verification/panels/RequestCameraAccessPanel.jsx
+++ b/src/id-verification/panels/RequestCameraAccessPanel.jsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useContext } from 'react';
+import { useEffect, useContext } from 'react';
 import { Link } from 'react-router-dom';
 import Bowser from 'bowser';
 import { getConfig } from '@edx/frontend-platform';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
-import { injectIntl, intlShape, FormattedMessage } from '@edx/frontend-platform/i18n';
+import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 
 import { useRedirect } from '../../hooks';
 import { useNextPanelSlug } from '../routing-utilities';
@@ -14,7 +14,8 @@ import { UnsupportedCameraDirectionsPanel } from './UnsupportedCameraDirectionsP
 
 import messages from '../IdVerification.messages';
 
-const RequestCameraAccessPanel = (props) => {
+const RequestCameraAccessPanel = () => {
+  const intl = useIntl();
   const { location: returnUrl, text: returnText } = useRedirect();
   const panelSlug = 'request-camera-access';
   const nextPanelSlug = useNextPanelSlug(panelSlug);
@@ -40,17 +41,17 @@ const RequestCameraAccessPanel = (props) => {
 
   const getTitle = () => {
     if (mediaAccess === MEDIA_ACCESS.GRANTED) {
-      return props.intl.formatMessage(messages['id.verification.camera.access.title.success']);
+      return intl.formatMessage(messages['id.verification.camera.access.title.success']);
     }
     if ([MEDIA_ACCESS.UNSUPPORTED, MEDIA_ACCESS.DENIED].includes(mediaAccess)) {
-      return props.intl.formatMessage(messages['id.verification.camera.access.title.failed']);
+      return intl.formatMessage(messages['id.verification.camera.access.title.failed']);
     }
-    return props.intl.formatMessage(messages['id.verification.camera.access.title']);
+    return intl.formatMessage(messages['id.verification.camera.access.title']);
   };
 
   const returnLink = (
     <a className="btn btn-primary" href={`${getConfig().LMS_BASE_URL}/${returnUrl}`}>
-      {props.intl.formatMessage(messages[returnText])}
+      {intl.formatMessage(messages[returnText])}
     </a>
   );
 
@@ -67,13 +68,13 @@ const RequestCameraAccessPanel = (props) => {
               defaultMessage="In order to take a photo using your webcam, you may receive a browser prompt for access to your camera. {clickAllow}"
               description="Instructions to enable camera access."
               values={{
-                clickAllow: <strong>{props.intl.formatMessage(messages['id.verification.camera.access.click.allow'])}</strong>,
+                clickAllow: <strong>{intl.formatMessage(messages['id.verification.camera.access.click.allow'])}</strong>,
               }}
             />
           </p>
           <div className="action-row">
             <button type="button" className="btn btn-primary" onClick={tryGetUserMedia}>
-              {props.intl.formatMessage(messages['id.verification.camera.access.enable'])}
+              {intl.formatMessage(messages['id.verification.camera.access.enable'])}
             </button>
           </div>
         </div>
@@ -82,11 +83,11 @@ const RequestCameraAccessPanel = (props) => {
       {mediaAccess === MEDIA_ACCESS.GRANTED && (
         <div>
           <p data-testid="camera-access-success">
-            {props.intl.formatMessage(messages['id.verification.camera.access.success'])}
+            {intl.formatMessage(messages['id.verification.camera.access.success'])}
           </p>
           <div className="action-row">
             <Link to={`/id-verification/${nextPanelSlug}`} className="btn btn-primary" data-testid="next-button">
-              {props.intl.formatMessage(messages['id.verification.next'])}
+              {intl.formatMessage(messages['id.verification.next'])}
             </Link>
           </div>
         </div>
@@ -95,9 +96,9 @@ const RequestCameraAccessPanel = (props) => {
       {mediaAccess === MEDIA_ACCESS.DENIED && (
         <div data-testid="camera-failure-instructions">
           <p data-testid="camera-access-failure">
-            {props.intl.formatMessage(messages['id.verification.camera.access.failure.temporary'])}
+            {intl.formatMessage(messages['id.verification.camera.access.failure.temporary'])}
           </p>
-          <EnableCameraDirectionsPanel browserName={browserName} intl={props.intl} />
+          <EnableCameraDirectionsPanel browserName={browserName} />
           <div className="action-row">
             {returnLink}
           </div>
@@ -107,9 +108,9 @@ const RequestCameraAccessPanel = (props) => {
       {mediaAccess === MEDIA_ACCESS.UNSUPPORTED && (
         <div data-testid="camera-unsupported-instructions">
           <p data-testid="camera-unsupported-failure">
-            {props.intl.formatMessage(messages['id.verification.camera.access.failure.unsupported'])}
+            {intl.formatMessage(messages['id.verification.camera.access.failure.unsupported'])}
           </p>
-          <UnsupportedCameraDirectionsPanel browserName={browserName} intl={props.intl} />
+          <UnsupportedCameraDirectionsPanel browserName={browserName} intl={intl} />
           <div className="action-row">
             {returnLink}
           </div>
@@ -120,8 +121,4 @@ const RequestCameraAccessPanel = (props) => {
   );
 };
 
-RequestCameraAccessPanel.propTypes = {
-  intl: intlShape.isRequired,
-};
-
-export default injectIntl(RequestCameraAccessPanel);
+export default RequestCameraAccessPanel;

--- a/src/id-verification/tests/panels/PortraitPhotoContextPanel.test.jsx
+++ b/src/id-verification/tests/panels/PortraitPhotoContextPanel.test.jsx
@@ -1,10 +1,9 @@
-import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import {
   render, cleanup, act, screen, fireEvent,
 } from '@testing-library/react';
 import '@edx/frontend-platform/analytics';
-import { injectIntl, IntlProvider } from '@edx/frontend-platform/i18n';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
 import PortraitPhotoContextPanel from '../../panels/PortraitPhotoContextPanel';
 import IdVerificationContext from '../../IdVerificationContext';
 
@@ -12,13 +11,7 @@ jest.mock('@edx/frontend-platform/analytics', () => ({
   sendTrackEvent: jest.fn(),
 }));
 
-const IntlPortraitPhotoContextPanel = injectIntl(PortraitPhotoContextPanel);
-
 describe('PortraitPhotoContextPanel', () => {
-  const defaultProps = {
-    intl: {},
-  };
-
   const contextValue = { reachedSummary: false };
 
   afterEach(() => {
@@ -30,7 +23,7 @@ describe('PortraitPhotoContextPanel', () => {
       <Router>
         <IntlProvider locale="en">
           <IdVerificationContext.Provider value={contextValue}>
-            <IntlPortraitPhotoContextPanel {...defaultProps} />
+            <PortraitPhotoContextPanel />
           </IdVerificationContext.Provider>
         </IntlProvider>
       </Router>
@@ -46,7 +39,7 @@ describe('PortraitPhotoContextPanel', () => {
       <Router>
         <IntlProvider locale="en">
           <IdVerificationContext.Provider value={contextValue}>
-            <IntlPortraitPhotoContextPanel {...defaultProps} />
+            <PortraitPhotoContextPanel />
           </IdVerificationContext.Provider>
         </IntlProvider>
       </Router>

--- a/src/id-verification/tests/panels/RequestCameraAccessPanel.test.jsx
+++ b/src/id-verification/tests/panels/RequestCameraAccessPanel.test.jsx
@@ -5,7 +5,7 @@ import {
   render, screen, cleanup, act, fireEvent,
 } from '@testing-library/react';
 import { getConfig } from '@edx/frontend-platform';
-import { injectIntl, IntlProvider } from '@edx/frontend-platform/i18n';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
 import IdVerificationContext from '../../IdVerificationContext';
 import RequestCameraAccessPanel from '../../panels/RequestCameraAccessPanel';
 
@@ -15,13 +15,7 @@ jest.mock('@edx/frontend-platform/analytics', () => ({
 
 jest.mock('bowser');
 
-const IntlRequestCameraAccessPanel = injectIntl(RequestCameraAccessPanel);
-
 describe('RequestCameraAccessPanel', () => {
-  const defaultProps = {
-    intl: {},
-  };
-
   const contextValue = {
     reachedSummary: false,
     tryGetUserMedia: jest.fn(),
@@ -38,7 +32,7 @@ describe('RequestCameraAccessPanel', () => {
       <Router>
         <IntlProvider locale="en">
           <IdVerificationContext.Provider value={contextValue}>
-            <IntlRequestCameraAccessPanel {...defaultProps} />
+            <RequestCameraAccessPanel />
           </IdVerificationContext.Provider>
         </IntlProvider>
       </Router>
@@ -54,7 +48,7 @@ describe('RequestCameraAccessPanel', () => {
       <Router>
         <IntlProvider locale="en">
           <IdVerificationContext.Provider value={contextValue}>
-            <IntlRequestCameraAccessPanel {...defaultProps} />
+            <RequestCameraAccessPanel />
           </IdVerificationContext.Provider>
         </IntlProvider>
       </Router>
@@ -73,7 +67,7 @@ describe('RequestCameraAccessPanel', () => {
       <Router>
         <IntlProvider locale="en">
           <IdVerificationContext.Provider value={contextValue}>
-            <IntlRequestCameraAccessPanel {...defaultProps} />
+            <RequestCameraAccessPanel />
           </IdVerificationContext.Provider>
         </IntlProvider>
       </Router>
@@ -89,7 +83,7 @@ describe('RequestCameraAccessPanel', () => {
       <Router>
         <IntlProvider locale="en">
           <IdVerificationContext.Provider value={contextValue}>
-            <IntlRequestCameraAccessPanel {...defaultProps} />
+            <RequestCameraAccessPanel />
           </IdVerificationContext.Provider>
         </IntlProvider>
       </Router>
@@ -106,7 +100,7 @@ describe('RequestCameraAccessPanel', () => {
       <Router>
         <IntlProvider locale="en">
           <IdVerificationContext.Provider value={contextValue}>
-            <IntlRequestCameraAccessPanel {...defaultProps} />
+            <RequestCameraAccessPanel />
           </IdVerificationContext.Provider>
         </IntlProvider>
       </Router>
@@ -123,7 +117,7 @@ describe('RequestCameraAccessPanel', () => {
       <Router>
         <IntlProvider locale="en">
           <IdVerificationContext.Provider value={contextValue}>
-            <IntlRequestCameraAccessPanel {...defaultProps} />
+            <RequestCameraAccessPanel />
           </IdVerificationContext.Provider>
         </IntlProvider>
       </Router>
@@ -139,7 +133,7 @@ describe('RequestCameraAccessPanel', () => {
       <Router>
         <IntlProvider locale="en">
           <IdVerificationContext.Provider value={contextValue}>
-            <IntlRequestCameraAccessPanel {...defaultProps} />
+            <RequestCameraAccessPanel />
           </IdVerificationContext.Provider>
         </IntlProvider>
       </Router>
@@ -155,7 +149,7 @@ describe('RequestCameraAccessPanel', () => {
       <Router>
         <IntlProvider locale="en">
           <IdVerificationContext.Provider value={contextValue}>
-            <IntlRequestCameraAccessPanel {...defaultProps} />
+            <RequestCameraAccessPanel />
           </IdVerificationContext.Provider>
         </IntlProvider>
       </Router>
@@ -171,7 +165,7 @@ describe('RequestCameraAccessPanel', () => {
       <Router>
         <IntlProvider locale="en">
           <IdVerificationContext.Provider value={contextValue}>
-            <IntlRequestCameraAccessPanel {...defaultProps} />
+            <RequestCameraAccessPanel />
           </IdVerificationContext.Provider>
         </IntlProvider>
       </Router>
@@ -188,7 +182,7 @@ describe('RequestCameraAccessPanel', () => {
       <Router>
         <IntlProvider locale="en">
           <IdVerificationContext.Provider value={contextValue}>
-            <IntlRequestCameraAccessPanel {...defaultProps} />
+            <RequestCameraAccessPanel />
           </IdVerificationContext.Provider>
         </IntlProvider>
       </Router>
@@ -205,7 +199,7 @@ describe('RequestCameraAccessPanel', () => {
       <Router>
         <IntlProvider locale="en">
           <IdVerificationContext.Provider value={contextValue}>
-            <IntlRequestCameraAccessPanel {...defaultProps} />
+            <RequestCameraAccessPanel />
           </IdVerificationContext.Provider>
         </IntlProvider>
       </Router>


### PR DESCRIPTION
### Description
As part of the project for improvements as follow up of react-unit-test-utils, we are going to replace all usages of the deprecated `injectIntl` HOC with the `useIntl()` hook from @edx/frontend-platform/i18n. It is a very straight-forward change, in order to accomplish this we did the following changes:

- In components we have to remove the old `injectIntl`, remove intl as a prop and use the hook instead.
- In tests we need to stop using `injectIntl` and just use the desired component wrapped in a `IntlProvider` (from @edx/frontend-platform/i18n).

Files to refactor:
- src/id-verification/panels/EnableCameraDirectionsPanel.jsx
- src/id-verification/panels/PortraitPhotoContextPanel.jsx
- src/id-verification/tests/panels/PortraitPhotoContextPanel.test.jsx
- src/id-verification/panels/RequestCameraAccessPanel.jsx
- src/id-verification/tests/panels/RequestCameraAccessPanel.test.jsx

#### Support information
Closes #1293 