### PR TITLE
feat: add dev script to package.json

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,6 +104,12 @@ Cloning and Startup
 
     ``npm start``
 
+    Or for local development with custom configuration:
+
+    ``npm run dev``
+
+    This runs the dev server with PUBLIC_PATH=/account/, MFE_CONFIG_API_URL pointing to localhost:8000, and hosts on apps.local.openedx.io.
+
 Local module development
 =========================
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "build": "fedx-scripts webpack",
+    "dev": "PUBLIC_PATH=/account/ MFE_CONFIG_API_URL='http://localhost:8000/api/mfe_config/v1' fedx-scripts webpack-dev-server --progress --host apps.local.openedx.io",
     "i18n_extract": "fedx-scripts formatjs extract",
     "lint": "fedx-scripts eslint --ext .js --ext .jsx .",
     "lint:fix": "npm run lint -- --fix",


### PR DESCRIPTION
Added a new npm run dev script for local development with pre-configured Open edX settings.
Changes:

Added dev script to package.json that runs webpack-dev-server with Open edX-specific configuration
Updated README.rst to document the new dev command and explain what it does

This provides developers with a convenient way to start the development server with the correct PUBLIC_PATH, MFE_CONFIG_API_URL, and host settings for Open edX local development.
How Has This Been Tested?

Verified the new npm run dev command starts the development server successfully
Confirmed the server runs on the correct host (apps.local.openedx.io)
Tested that the PUBLIC_PATH and MFE_CONFIG_API_URL environment variables are properly set

#### Screenshots/sandbox (optional):

https://github.com/user-attachments/assets/848085db-3981-4179-82ac-7a9e01597932

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.