### PR TITLE
chore: updated the notification section description

### DIFF
--- a/src/notification-preferences/NotificationSettings.jsx
+++ b/src/notification-preferences/NotificationSettings.jsx
@@ -21,12 +21,9 @@ const NotificationSettings = () => {
           {intl.formatMessage(messages.notificationHeading)}
         </h2>
         <div className="text-gray-700 font-size-14 mb-3">
-          {intl.formatMessage(messages.accountNotificationDescription)}
-        </div>
-        <div className="text-gray-700 font-size-14 mb-3">
           {intl.formatMessage(messages.notificationCadenceDescription, {
             dailyTime: '22:00 UTC',
-            weeklyTime: '22:00 UTC Every Sunday',
+            weeklyTime: '22:00 UTC',
           })}
         </div>
         <div className="mb-5 text-gray-700 font-size-14">

--- a/src/notification-preferences/NotificationSettings.jsx
+++ b/src/notification-preferences/NotificationSettings.jsx
@@ -22,8 +22,7 @@ const NotificationSettings = () => {
         </h2>
         <div className="text-gray-700 font-size-14 mb-3">
           {intl.formatMessage(messages.notificationCadenceDescription, {
-            dailyTime: '22:00 UTC',
-            weeklyTime: '22:00 UTC',
+            dailyTime: '22:00 UTC', weeklyTime: '22:00 UTC',
           })}
         </div>
         <div className="mb-5 text-gray-700 font-size-14">

--- a/src/notification-preferences/messages.js
+++ b/src/notification-preferences/messages.js
@@ -91,14 +91,9 @@ const messages = defineMessages({
     defaultMessage: 'Notifications for certain activities are enabled by default,',
     description: 'Body of the notification preferences for learner guide',
   },
-  accountNotificationDescription: {
-    id: 'account.notification.description',
-    defaultMessage: 'Account-level settings apply to all courses.',
-    description: 'Account notification description',
-  },
   notificationCadenceDescription: {
     id: 'notification.cadence.description',
-    defaultMessage: 'Daily notifications are delivered at {dailyTime}. Weekly notifications are delivered at {weeklyTime}.',
+    defaultMessage: 'Daily email notifications are sent at {dailyTime}. Weekly email notifications are sent every Sunday at {weeklyTime}.',
     description: 'Notification cadence description',
   },
   notificationDefaultInfo: {


### PR DESCRIPTION
Ticket: [INF-2087](https://2u-internal.atlassian.net/browse/INF-2087)

Since we have removed course level preferences dropdown and default is account level, we need to remove this line:
`Account-level settings apply to all courses.`

Also, modify the second line as follows:
`Daily email notifications are sent at 22:00 UTC. Weekly email notifications are sent every Sunday at 22:00 UTC.`