### PR TITLE
Replace connect with useSelector() and useDispatch() 1/2

### DIFF
--- a/src/account-settings/BetaLanguageBanner.jsx
+++ b/src/account-settings/BetaLanguageBanner.jsx
@@ -1,8 +1,7 @@
 import { useContext } from 'react';
-import PropTypes from 'prop-types';
 import { AppContext } from '@edx/frontend-platform/react';
 import { useIntl } from '@edx/frontend-platform/i18n';
-import { connect } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { Button, Hyperlink } from '@openedx/paragon';
 
 import { betaLanguageBannerSelector } from './data/selectors';
@@ -11,8 +10,10 @@ import { saveSettings } from './data/actions';
 import { TRANSIFEX_LANGUAGE_BASE_URL } from './data/constants';
 import Alert from './Alert';
 
-const BetaLanguageBanner = ({ siteLanguage = null, siteLanguageList }) => {
+const BetaLanguageBanner = () => {
   const intl = useIntl();
+  const dispatch = useDispatch();
+  const { siteLanguage = null, siteLanguageList = [] } = useSelector(betaLanguageBannerSelector);
   const { locale } = useContext(AppContext);
 
   const getSiteLanguageEntry = (languageCode) => siteLanguageList.filter(l => l.code === languageCode)[0];
@@ -43,7 +44,7 @@ const BetaLanguageBanner = ({ siteLanguage = null, siteLanguageList }) => {
 
   const handleRevertLanguage = () => {
     const previousSiteLanguage = siteLanguage.previousValue;
-    saveSettings('siteLanguage', previousSiteLanguage);
+    dispatch(saveSettings('siteLanguage', previousSiteLanguage));
   };
 
   const savedLanguage = getSiteLanguageEntry(locale);
@@ -88,23 +89,4 @@ const BetaLanguageBanner = ({ siteLanguage = null, siteLanguageList }) => {
   );
 };
 
-BetaLanguageBanner.contextType = AppContext;
-
-BetaLanguageBanner.propTypes = {
-  siteLanguage: PropTypes.shape({
-    previousValue: PropTypes.string,
-    draft: PropTypes.string,
-  }),
-  siteLanguageList: PropTypes.arrayOf(PropTypes.shape({
-    name: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    code: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    released: PropTypes.bool,
-  })).isRequired,
-};
-
-export default connect(
-  betaLanguageBannerSelector,
-  {
-    saveSettings,
-  },
-)(BetaLanguageBanner);
+export default BetaLanguageBanner;

--- a/src/account-settings/DOBForm.jsx
+++ b/src/account-settings/DOBForm.jsx
@@ -4,21 +4,20 @@ import {
   Form, StatefulButton, ModalDialog, ActionRow, useToggle, Button,
 } from '@openedx/paragon';
 import { useCallback, useEffect, useState } from 'react';
-import { connect, useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import messages from './AccountSettingsPage.messages';
 import { YEAR_OF_BIRTH_OPTIONS } from './data/constants';
 import { editableFieldSelector } from './data/selectors';
 import { saveSettingsReset } from './data/actions';
 
-const DOBModal = (props) => {
+const DOBModal = ({ onSubmit }) => {
   const intl = useIntl();
-  const {
-    saveState,
-    error,
-    onSubmit,
-  } = props;
 
   const dispatch = useDispatch();
+  const {
+    saveState = undefined,
+    error = undefined,
+  } = useSelector((state) => editableFieldSelector(state, { name: 'extended_profile' }));
 
   // eslint-disable-next-line no-unused-vars
   const [isOpen, open, close, toggle] = useToggle(true, {});
@@ -148,14 +147,7 @@ const DOBModal = (props) => {
 };
 
 DOBModal.propTypes = {
-  saveState: PropTypes.oneOf(['default', 'pending', 'complete', 'error']),
-  error: PropTypes.string,
   onSubmit: PropTypes.func.isRequired,
 };
 
-DOBModal.defaultProps = {
-  saveState: undefined,
-  error: undefined,
-};
-
-export default connect(editableFieldSelector)(DOBModal);
+export default DOBModal;

--- a/src/account-settings/EditableField.jsx
+++ b/src/account-settings/EditableField.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import classNames from 'classnames';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import {
@@ -26,20 +26,19 @@ const EditableField = (props) => {
     type,
     value,
     userSuppliedValue,
-    saveState,
-    error,
     confirmationMessageDefinition,
-    confirmationValue,
     helpText,
-    onEdit,
-    onCancel,
     onSubmit,
     onChange,
-    isEditing,
     isEditable,
     isGrayedOut,
     ...others
   } = props;
+
+  const dispatch = useDispatch();
+  const {
+    isEditing, saveState, error, confirmationValue,
+  } = useSelector(state => editableFieldSelector(state, props));
   const id = `field-${name}`;
   const intl = useIntl();
 
@@ -53,11 +52,11 @@ const EditableField = (props) => {
   };
 
   const handleEdit = () => {
-    onEdit(name);
+    dispatch(openForm(name));
   };
 
   const handleCancel = () => {
-    onCancel(name);
+    dispatch(closeForm(name));
   };
 
   const renderEmptyLabel = () => {
@@ -171,40 +170,27 @@ EditableField.propTypes = {
   type: PropTypes.string.isRequired,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   userSuppliedValue: PropTypes.string,
-  saveState: PropTypes.oneOf(['default', 'pending', 'complete', 'error']),
-  error: PropTypes.string,
   confirmationMessageDefinition: PropTypes.shape({
     id: PropTypes.string.isRequired,
     defaultMessage: PropTypes.string.isRequired,
     description: PropTypes.string,
   }),
-  confirmationValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   helpText: PropTypes.node,
-  onEdit: PropTypes.func.isRequired,
-  onCancel: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
   onChange: PropTypes.func.isRequired,
-  isEditing: PropTypes.bool,
   isEditable: PropTypes.bool,
   isGrayedOut: PropTypes.bool,
 };
 
 EditableField.defaultProps = {
   value: undefined,
-  saveState: undefined,
   label: undefined,
   emptyLabel: undefined,
-  error: undefined,
   confirmationMessageDefinition: undefined,
-  confirmationValue: undefined,
   helpText: undefined,
-  isEditing: false,
   isEditable: true,
   isGrayedOut: false,
   userSuppliedValue: undefined,
 };
 
-export default connect(editableFieldSelector, {
-  onEdit: openForm,
-  onCancel: closeForm,
-})(EditableField);
+export default EditableField;

--- a/src/account-settings/EditableSelectField.jsx
+++ b/src/account-settings/EditableSelectField.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import {
   Button, Form, StatefulButton,
@@ -19,6 +19,10 @@ import CertificatePreference from './certificate-preference/CertificatePreferenc
 
 const EditableSelectField = (props) => {
   const intl = useIntl();
+  const dispatch = useDispatch();
+  const {
+    error, confirmationValue, saveState, isEditing,
+  } = useSelector((state) => editableFieldSelector(state, props));
   const {
     name,
     label,
@@ -27,16 +31,10 @@ const EditableSelectField = (props) => {
     value,
     userSuppliedValue,
     options,
-    saveState,
-    error,
     confirmationMessageDefinition,
-    confirmationValue,
     helpText,
-    onEdit,
-    onCancel,
     onSubmit,
     onChange,
-    isEditing,
     isEditable,
     isGrayedOut,
     ...others
@@ -53,11 +51,11 @@ const EditableSelectField = (props) => {
   };
 
   const handleEdit = () => {
-    onEdit(name);
+    dispatch(openForm(name));
   };
 
   const handleCancel = () => {
-    onCancel(name);
+    dispatch(closeForm(name));
   };
 
   const renderEmptyLabel = () => {
@@ -210,20 +208,14 @@ EditableSelectField.propTypes = {
     label: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   })),
-  saveState: PropTypes.oneOf(['default', 'pending', 'complete', 'error']),
-  error: PropTypes.string,
   confirmationMessageDefinition: PropTypes.shape({
     id: PropTypes.string.isRequired,
     defaultMessage: PropTypes.string.isRequired,
     description: PropTypes.string,
   }),
-  confirmationValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   helpText: PropTypes.node,
-  onEdit: PropTypes.func.isRequired,
-  onCancel: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
   onChange: PropTypes.func.isRequired,
-  isEditing: PropTypes.bool,
   isEditable: PropTypes.bool,
   isGrayedOut: PropTypes.bool,
 };
@@ -231,20 +223,13 @@ EditableSelectField.propTypes = {
 EditableSelectField.defaultProps = {
   value: undefined,
   options: [],
-  saveState: undefined,
   label: undefined,
   emptyLabel: undefined,
-  error: undefined,
   confirmationMessageDefinition: undefined,
-  confirmationValue: undefined,
   helpText: undefined,
-  isEditing: false,
   isEditable: true,
   isGrayedOut: false,
   userSuppliedValue: undefined,
 };
 
-export default connect(editableFieldSelector, {
-  onEdit: openForm,
-  onCancel: closeForm,
-})(EditableSelectField);
+export default EditableSelectField;

--- a/src/account-settings/EmailField.jsx
+++ b/src/account-settings/EmailField.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useIntl, FormattedMessage } from '@edx/frontend-platform/i18n';
 import {
   Button, StatefulButton, Form,
@@ -23,20 +23,18 @@ const EmailField = (props) => {
     label,
     emptyLabel,
     value,
-    saveState,
-    error,
     confirmationMessageDefinition,
-    confirmationValue,
     helpText,
-    onEdit,
-    onCancel,
     onSubmit,
     onChange,
-    isEditing,
     isEditable,
   } = props;
   const id = `field-${name}`;
   const intl = useIntl();
+  const dispatch = useDispatch();
+  const {
+    error, confirmationValue, saveState, isEditing = false,
+  } = useSelector(state => editableFieldSelector(state, props));
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -48,11 +46,11 @@ const EmailField = (props) => {
   };
 
   const handleEdit = () => {
-    onEdit(name);
+    dispatch(openForm(name));
   };
 
   const handleCancel = () => {
-    onCancel(name);
+    dispatch(closeForm(name));
   };
 
   const renderConfirmationMessage = () => {
@@ -175,37 +173,24 @@ EmailField.propTypes = {
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   emptyLabel: PropTypes.node,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  saveState: PropTypes.oneOf(['default', 'pending', 'complete', 'error']),
-  error: PropTypes.string,
   confirmationMessageDefinition: PropTypes.shape({
     id: PropTypes.string.isRequired,
     defaultMessage: PropTypes.string.isRequired,
     description: PropTypes.string,
   }),
-  confirmationValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   helpText: PropTypes.node,
-  onEdit: PropTypes.func.isRequired,
-  onCancel: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
   onChange: PropTypes.func.isRequired,
-  isEditing: PropTypes.bool,
   isEditable: PropTypes.bool,
 };
 
 EmailField.defaultProps = {
   value: undefined,
-  saveState: undefined,
   label: undefined,
   emptyLabel: undefined,
-  error: undefined,
   confirmationMessageDefinition: undefined,
-  confirmationValue: undefined,
   helpText: undefined,
-  isEditing: false,
   isEditable: true,
 };
 
-export default connect(editableFieldSelector, {
-  onEdit: openForm,
-  onCancel: closeForm,
-})(EmailField);
+export default EmailField;


### PR DESCRIPTION
### Description
In order to continue with the improvements and refactors, now we will replace all usage of `connect` HOC with `useSelector()` and `useDispatch()`.

We also need to mock redux state in tests, convert the tests to use initializeMocks from src/testUtils.tsx and pass in initialState to initializeMocks. Or use `const { reduxStore } = initializeMocks();` and dispatch changes to the redux store.

Files to refactor:
- src/account-settings/AccountSettingsPage.jsx - For this file we also removed other unnecesary HOCs as navigate and location
- src/account-settings/BetaLanguageBanner.jsx
- src/account-settings/DOBForm.jsx
- src/account-settings/EditableField.jsx
- src/account-settings/EditableSelectField.jsx
- src/account-settings/EmailField.jsx

#### Support Information
Closes #1309 