### PR TITLE
ulmoBackport: removed hard-coded waffle flag checks for email and push notifications

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+coverage:
+  status:
+    project:
+      default:
+        enabled: yes
+        target: auto
+        threshold: 0%
+    patch:
+      default:
+        enabled: yes
+        target: auto
+        threshold: 0%
+ignore:
+  - "src/i18n"
+  - "src/index.jsx"

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -65,8 +65,8 @@ initialize({
     config: () => {
       mergeConfig({
         SUPPORT_URL: process.env.SUPPORT_URL,
-        SHOW_PUSH_CHANNEL: process.env.SHOW_PUSH_CHANNEL === 'true',
-        SHOW_EMAIL_CHANNEL: process.env.SHOW_EMAIL_CHANNEL || 'false',
+        SHOW_PUSH_CHANNEL: process.env.SHOW_PUSH_CHANNEL || false,
+        SHOW_EMAIL_CHANNEL: process.env.SHOW_EMAIL_CHANNEL || false,
         ENABLE_COPPA_COMPLIANCE: (process.env.ENABLE_COPPA_COMPLIANCE || false),
         ENABLE_ACCOUNT_DELETION: (process.env.ENABLE_ACCOUNT_DELETION !== 'false'),
         COUNTRIES_WITH_DELETE_ACCOUNT_DISABLED: JSON.parse(process.env.COUNTRIES_WITH_DELETE_ACCOUNT_DISABLED || '[]'),

--- a/src/notification-preferences/NotificationPreferences.test.jsx
+++ b/src/notification-preferences/NotificationPreferences.test.jsx
@@ -3,7 +3,7 @@ import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import { BrowserRouter as Router } from 'react-router-dom';
 
-import { setConfig } from '@edx/frontend-platform';
+import { setConfig, mergeConfig } from '@edx/frontend-platform';
 import * as auth from '@edx/frontend-platform/auth';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { fireEvent, render, screen } from '@testing-library/react';
@@ -110,9 +110,10 @@ describe('Notification Preferences', () => {
   let store;
 
   beforeEach(() => {
-    setConfig({
+    mergeConfig({
       SHOW_EMAIL_CHANNEL: '',
-    });
+      SHOW_PUSH_CHANNEL: '',
+    }, 'App loadConfig override handler');
 
     store = setupStore({
       ...defaultPreferences,
@@ -172,6 +173,59 @@ describe('Notification Preferences', () => {
     expect(screen.getByTestId('toggle-core-email')).toBeDisabled();
     expect(screen.getAllByTestId('email-cadence-button')[0]).toBeDisabled();
     expect(screen.getByTestId('toggle-newGrade-web')).not.toBeDisabled();
+  });
+
+  it('does not render push channel when SHOW_PUSH_CHANNEL is false', async () => {
+    setConfig({
+      SHOW_PUSH_CHANNEL: '',
+    });
+    store = setupStore({
+      ...defaultPreferences,
+      status: SUCCESS_STATUS,
+      selectedCourse: '',
+    });
+    await render(notificationPreferences(store));
+
+    expect(screen.queryByTestId('toggle-core-push')).not.toBeInTheDocument();
+  });
+
+  it('renders push channel when SHOW_PUSH_CHANNEL is true', async () => {
+    setConfig({
+      SHOW_PUSH_CHANNEL: 'true',
+    });
+    store = setupStore({
+      ...defaultPreferences,
+      status: SUCCESS_STATUS,
+      selectedCourse: '',
+    });
+    await render(notificationPreferences(store));
+    expect(screen.queryByTestId('toggle-core-push')).toBeInTheDocument();
+  });
+
+  it('does not render email channel when SHOW_EMAIL_CHANNEL is false', async () => {
+    setConfig({
+      SHOW_EMAIL_CHANNEL: '',
+    });
+    store = setupStore({
+      ...defaultPreferences,
+      status: SUCCESS_STATUS,
+      selectedCourse: '',
+    });
+    await render(notificationPreferences(store));
+    expect(screen.queryByTestId('toggle-core-email')).not.toBeInTheDocument();
+  });
+
+  it('renders email channel when SHOW_EMAIL_CHANNEL is true', async () => {
+    setConfig({
+      SHOW_EMAIL_CHANNEL: 'true',
+    });
+    store = setupStore({
+      ...defaultPreferences,
+      status: SUCCESS_STATUS,
+      selectedCourse: '',
+    });
+    await render(notificationPreferences(store));
+    expect(screen.queryByTestId('toggle-core-email')).toBeInTheDocument();
   });
 });
 

--- a/src/notification-preferences/data/utils.js
+++ b/src/notification-preferences/data/utils.js
@@ -3,7 +3,7 @@ import { getConfig } from '@edx/frontend-platform';
 export const notificationChannels = () => ({
   WEB: 'web',
   ...(getConfig().SHOW_PUSH_CHANNEL && { PUSH: 'push' }),
-  ...(getConfig().SHOW_EMAIL_CHANNEL === 'true' && { EMAIL: 'email' }),
+  ...(getConfig().SHOW_EMAIL_CHANNEL && { EMAIL: 'email' }),
 });
 
 export const shouldHideAppPreferences = (preferences, appId) => {

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -1,6 +1,8 @@
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 import '@testing-library/jest-dom';
+import { initialize, mergeConfig } from '@edx/frontend-platform';
+import { MockAuthService } from '@edx/frontend-platform/auth';
 
 import MockedPluginSlot from './tests/MockedPluginSlot';
 
@@ -8,4 +10,40 @@ jest.mock('@openedx/frontend-plugin-framework', () => ({
   ...jest.requireActual('@openedx/frontend-plugin-framework'),
   Plugin: () => 'Plugin',
   PluginSlot: MockedPluginSlot,
+}));
+
+mergeConfig({
+  SUPPORT_URL: process.env.SUPPORT_URL || 'https://support.example.com',
+  SHOW_PUSH_CHANNEL: process.env.SHOW_PUSH_CHANNEL || false,
+  SHOW_EMAIL_CHANNEL: process.env.SHOW_EMAIL_CHANNEL || false,
+  ENABLE_COPPA_COMPLIANCE: (process.env.ENABLE_COPPA_COMPLIANCE || false),
+  ENABLE_ACCOUNT_DELETION: (process.env.ENABLE_ACCOUNT_DELETION !== 'false'),
+  COUNTRIES_WITH_DELETE_ACCOUNT_DISABLED: JSON.parse(process.env.COUNTRIES_WITH_DELETE_ACCOUNT_DISABLED || '[]'),
+  ENABLE_DOB_UPDATE: (process.env.ENABLE_DOB_UPDATE || false),
+  MARKETING_EMAILS_OPT_IN: (process.env.MARKETING_EMAILS_OPT_IN || false),
+  PASSWORD_RESET_SUPPORT_LINK: process.env.PASSWORD_RESET_SUPPORT_LINK || 'https://support.example.com/password-reset',
+  LEARNER_FEEDBACK_URL: process.env.LEARNER_FEEDBACK_URL || 'https://support.example.com/feedback',
+}, 'App loadConfig override handler');
+
+initialize({
+  handlers: {
+    config: () => {
+      mergeConfig({
+        authenticatedUser: {
+          userId: 'abc123',
+          username: 'Mock User',
+          roles: [],
+          administrator: false,
+        },
+      });
+    },
+  },
+  messages: [],
+  authService: MockAuthService,
+});
+
+global.ResizeObserver = jest.fn().mockImplementation(() => ({
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+  disconnect: jest.fn(),
 }));


### PR DESCRIPTION
**Issue**  
The flags SHOW_PUSH_CHANNEL and SHOW_EMAIL_CHANNEL explicitly check for the string 'true'. As a result, the Boolean value **True** was incorrectly treated as an "off" state due to this hard-coded check. Waffle flags should operate as Boolean values instead.  It will cause any community instance that uses a Boolean value.
- SHOW_PUSH_CHANNEL: `process.env.SHOW_PUSH_CHANNEL === 'true'`  
- `...(getConfig().SHOW_EMAIL_CHANNEL === 'true' && { EMAIL: 'email' }),`  

**Fix**  
The logic for the waffle flags in the account MFE has been corrected. If a flag is empty, missing, or not available in the config, it is now considered false. Any flag with a non-empty string value is considered true.  

**For Example**  
- If `SHOW_PUSH_CHANNEL = ''`, it will be treated as the flag being **off**.  
- If `SHOW_PUSH_CHANNEL = 'true'`, it will be treated as the flag being **on**.  