### PR TITLE
feat: added env parse to boolean functionality

### DIFF
--- a/src/notification-preferences/data/utils.js
+++ b/src/notification-preferences/data/utils.js
@@ -1,9 +1,11 @@
 import { getConfig } from '@edx/frontend-platform';
 
+import { parseEnvBoolean } from '../../utils';
+
 export const notificationChannels = () => ({
   WEB: 'web',
-  ...(getConfig().SHOW_PUSH_CHANNEL && { PUSH: 'push' }),
-  ...(getConfig().SHOW_EMAIL_CHANNEL && { EMAIL: 'email' }),
+  ...(parseEnvBoolean(getConfig().SHOW_PUSH_CHANNEL) && { PUSH: 'push' }),
+  ...(parseEnvBoolean(getConfig().SHOW_EMAIL_CHANNEL) && { EMAIL: 'email' }),
 });
 
 export const shouldHideAppPreferences = (preferences, appId) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -38,3 +38,13 @@ export function getMostRecentApprovedOrPendingVerifiedName(verifiedNames) {
 
   return applicableName;
 }
+
+/**
+ * Parse an environment variable string value to a boolean.
+ * @param {string} value the environment variable string value
+ * @returns {boolean} the parsed boolean value
+ */
+export const parseEnvBoolean = (value) => {
+  if (!value) { return false; }
+  return String(value).toLowerCase() === 'true';
+};


### PR DESCRIPTION
### Description
- Added a helper function that will convert the env boolean string into a boolean value.

**For example**
'True', 'False', 'true', 'false', ''  into Boolean true and false