### PR TITLE
Fix X / twitter broken tests

### DIFF
--- a/src/account-settings/data/service.test.js
+++ b/src/account-settings/data/service.test.js
@@ -38,24 +38,24 @@ describe('account service', () => {
     it('returns unpacked account data', async () => {
       const apiResponse = {
         username: 'testuser',
-        social_links: [{ platform: 'twitter', social_link: 'http://t' }],
+        social_links: [{ platform: 'xTwitter', social_link: 'http://t' }],
         language_proficiencies: [{ code: 'en' }],
       };
       mockHttpClient.get.mockResolvedValue({ data: apiResponse });
 
       const result = await getAccount('testuser');
       expect(mockHttpClient.get).toHaveBeenCalledWith('http://lms.test/api/user/v1/accounts/testuser');
-      expect(result.social_link_twitter).toEqual('http://t');
+      expect(result.social_link_x).toEqual('http://t');
       expect(result.language_proficiencies).toEqual('en');
     });
   });
 
   describe('patchAccount', () => {
     it('sends packed commit data and returns unpacked response', async () => {
-      const commit = { social_link_twitter: 'http://t' };
+      const commit = { social_link_x: 'http://t' };
       const apiResponse = {
         username: 'testuser',
-        social_links: [{ platform: 'twitter', social_link: 'http://t' }],
+        social_links: [{ platform: 'xTwitter', social_link: 'http://t' }],
         language_proficiencies: [],
       };
       mockHttpClient.patch.mockResolvedValue({ data: apiResponse });
@@ -63,10 +63,10 @@ describe('account service', () => {
       const result = await patchAccount('testuser', commit);
       expect(mockHttpClient.patch).toHaveBeenCalledWith(
         'http://lms.test/api/user/v1/accounts/testuser',
-        expect.objectContaining({ social_links: [{ platform: 'twitter', social_link: 'http://t' }] }),
+        expect.objectContaining({ social_links: [{ platform: 'xTwitter', social_link: 'http://t' }] }),
         expect.any(Object),
       );
-      expect(result.social_link_twitter).toEqual('http://t');
+      expect(result.social_link_x).toEqual('http://t');
     });
   });
 

--- a/src/account-settings/test/AccountSettingsPage.test.jsx
+++ b/src/account-settings/test/AccountSettingsPage.test.jsx
@@ -11,6 +11,7 @@ import { IntlProvider, injectIntl } from '@edx/frontend-platform/i18n';
 
 import AccountSettingsPage from '../AccountSettingsPage';
 import mockData from './mockData';
+import messages from '../AccountSettingsPage.messages';
 
 const mockDispatch = jest.fn();
 jest.mock('@edx/frontend-platform/analytics', () => ({
@@ -189,7 +190,7 @@ describe('AccountSettingsPage', () => {
 
     expect(screen.getByText('https://linkedin.com/in/testuser')).toBeInTheDocument();
     expect(screen.getByText('Add Facebook profile')).toBeInTheDocument();
-    expect(screen.getByText('Add Twitter profile')).toBeInTheDocument();
+    expect(screen.getByText(messages['account.settings.field.social.platform.name.xTwitter.empty'].defaultMessage)).toBeInTheDocument();
   });
 
   it('renders Site Preferences section with correct field values', () => {


### PR DESCRIPTION
### Description
The changes made on https://github.com/openedx/frontend-app-account/pull/1215 broke some tests related to X/Twitter, so we are fixing this to unblock master branch

#### How Has This Been Tested?
Fix unit tests and ran it on local, passing successfully
<img width="679" height="271" alt="Screenshot 2026-01-13 at 11 04 31 a m" src="https://github.com/user-attachments/assets/a7497c6e-04de-4757-a571-69cfe80bcfee" />

### Support information
Fixes #1395 

#### Merge Checklist
* [x] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.