### PR TITLE
fix: hide notifications jump-nav entry when feature flag is disabled

### DIFF
--- a/src/account-settings/JumpNav.jsx
+++ b/src/account-settings/JumpNav.jsx
@@ -2,13 +2,16 @@ import { getConfig } from '@edx/frontend-platform';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { breakpoints, useWindowSize } from '@openedx/paragon';
 import classNames from 'classnames';
+import { useSelector } from 'react-redux';
 import { NavHashLink } from 'react-router-hash-link';
 import Scrollspy from 'react-scrollspy';
+import { selectShowPreferences } from '../notification-preferences/data/selectors';
 import messages from './AccountSettingsPage.messages';
 
 const JumpNav = () => {
   const intl = useIntl();
   const stickToTop = useWindowSize().width > breakpoints.small.minWidth;
+  const showNotifications = useSelector(selectShowPreferences());
 
   return (
     <div className={classNames('jump-nav', { 'jump-nav-sm position-sticky pt-3': stickToTop })}>
@@ -17,7 +20,7 @@ const JumpNav = () => {
           'basic-information',
           'profile-information',
           'social-media',
-          'notifications',
+          ...(showNotifications ? ['notifications'] : []),
           'site-preferences',
           'linked-accounts',
           'delete-account',
@@ -41,11 +44,13 @@ const JumpNav = () => {
             {intl.formatMessage(messages['account.settings.section.social.media'])}
           </NavHashLink>
         </li>
-        <li>
-          <NavHashLink to="#notifications">
-            {intl.formatMessage(messages['notification.preferences.notifications.label'])}
-          </NavHashLink>
-        </li>
+        {showNotifications && (
+          <li>
+            <NavHashLink to="#notifications">
+              {intl.formatMessage(messages['notification.preferences.notifications.label'])}
+            </NavHashLink>
+          </li>
+        )}
         <li>
           <NavHashLink to="#site-preferences">
             {intl.formatMessage(messages['account.settings.section.site.preferences'])}

--- a/src/account-settings/test/JumpNav.test.jsx
+++ b/src/account-settings/test/JumpNav.test.jsx
@@ -61,4 +61,40 @@ describe('JumpNav', () => {
 
     expect(await screen.findByText('Delete My Account')).toBeVisible();
   });
+
+  it('should not render notifications link when showPreferences is false', async () => {
+    store = configureStore({
+      notificationPreferences: {
+        showPreferences: false,
+      },
+    });
+
+    render(
+      <IntlProvider locale="en">
+        <AppProvider store={store}>
+          <JumpNav />
+        </AppProvider>
+      </IntlProvider>,
+    );
+
+    expect(screen.queryByText('Notifications')).toBeNull();
+  });
+
+  it('should render notifications link when showPreferences is true', async () => {
+    store = configureStore({
+      notificationPreferences: {
+        showPreferences: true,
+      },
+    });
+
+    render(
+      <IntlProvider locale="en">
+        <AppProvider store={store}>
+          <JumpNav />
+        </AppProvider>
+      </IntlProvider>,
+    );
+
+    expect(await screen.findByText('Notifications')).toBeVisible();
+  });
 });


### PR DESCRIPTION
### Description

`NotificationSettings` already hides its own section when `state.notificationPreferences.showPreferences` is `false` (see [`src/notification-preferences/NotificationSettings.jsx`](https://github.com/openedx/frontend-app-account/blob/master/src/notification-preferences/NotificationSettings.jsx)), but `JumpNav` unconditionally rendered both the Scrollspy `'notifications'` item and the `<NavHashLink to="#notifications">` list item.

As a result, on deployments where the notifications feature is disabled - or simply before the `fetchNotificationPreferences` thunk resolves - users saw a stray "Notifications" link in the right-hand jump nav that scrolled to an anchor that did not exist on the page.

This PR subscribes `JumpNav` to the same `selectShowPreferences()` selector that `NotificationSettings` uses, so the jump-nav entry appears if and only if the corresponding section is actually rendered below. No other jump-nav items are changed; the fix is limited to the notifications entry.


#### How Has This Been Tested?

**Manual (reproduction)** - to verify locally:
    1. Start the account MFE against an Open edX instance where notification preferences are disabled for the authenticated user.
    2. Navigate to `/account` and observe the right-hand jump nav: the "Notifications" item should not be present.
    3. Enable notification preferences for the user (or point at an instance where they are enabled) and reload `/account`: the "Notifications" item should appear and clicking it should scroll to the rendered notifications section.

#### Screenshots/sandbox (optional):

| Before | After |
|--------|-------|
| "Notifications" entry visible in the jump nav while the notifications section itself is hidden - clicking it scrolls nowhere. | "Notifications" entry is hidden whenever the notifications section is hidden; shown only when the section renders. |

#### With disabled notifications
<img width="1177" height="663" alt="image" src="https://github.com/user-attachments/assets/d5bf7eef-4b0d-4e1d-abbf-613232e5ec41" />

#### With enabled notifications
<img width="2974" height="1678" alt="image" src="https://github.com/user-attachments/assets/a1235ed5-831c-458d-8b3e-a163edbd7d42" />


#### Merge Checklist

- [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
- [x] Is there adequate test coverage for your changes?

#### Post-merge Checklist

- [ ] Deploy the changes to prod after verifying on stage or ask **@jacobo-dominguez-wgu** to do it.
- [ ] 🎉 🙌 Celebrate! Thanks for your contribution.