### PR TITLE
feat: add oraReminder message to notification preferences

### DIFF
--- a/src/notification-preferences/messages.js
+++ b/src/notification-preferences/messages.js
@@ -30,6 +30,7 @@ const messages = defineMessages({
       oraStaffNotifications {New ORA submission for staff grading}
       oraGradeAssigned {Essay assignment grade received}
       newInstructorAllLearnersPost {New posts from instructors}
+      oraReminder {Essay assignment reminders}
       other {{text}}
     }`,
     description: 'Display text for Notification Types',


### PR DESCRIPTION
This PR adds a new message key, oraReminder, to the notification preferences messages. This key will be used to display essay assignment reminders in the notification types.