### PR TITLE
fix: update notification digest schedule to match Celery defaults

### DIFF
--- a/src/notification-preferences/NotificationSettings.jsx
+++ b/src/notification-preferences/NotificationSettings.jsx
@@ -22,7 +22,7 @@ const NotificationSettings = () => {
         </h2>
         <div className="text-gray-700 font-size-14 mb-3">
           {intl.formatMessage(messages.notificationCadenceDescription, {
-            dailyTime: '22:00 UTC', weeklyTime: '22:00 UTC',
+            dailyTime: '17:00 UTC', weeklyTime: '17:00 UTC',
           })}
         </div>
         <div className="mb-5 text-gray-700 font-size-14">

--- a/src/notification-preferences/messages.js
+++ b/src/notification-preferences/messages.js
@@ -94,7 +94,7 @@ const messages = defineMessages({
   },
   notificationCadenceDescription: {
     id: 'notification.cadence.description',
-    defaultMessage: 'Daily email notifications are sent at {dailyTime}. Weekly email notifications are sent every Sunday at {weeklyTime}.',
+    defaultMessage: 'Daily email notifications are sent at {dailyTime}. Weekly email notifications are sent every Monday at {weeklyTime}.',
     description: 'Notification cadence description',
   },
   notificationDefaultInfo: {


### PR DESCRIPTION
### Summary

Updates the hard-coded email notification digest schedule displayed on the preferences page to match the default Celery task configuration in `openedx-platform`.

### Background

The schedule text shown to learners ("Daily email notifications are sent at X. Weekly email notifications are sent every Y at Z.") was previously based on Ulmo cron job defaults. The platform has since migrated to Celery, which has different defaults.

A full dynamic solution (fetching the schedule from the backend) is tracked in [#1448](https://github.com/openedx/frontend-app-account/issues/1448). This is a minimal fix to keep the displayed values accurate in the interim.

### Changes

| | Before | After |
|---|---|---|
| Daily time | 22:00 UTC | 17:00 UTC |
| Weekly day | Sunday | Monday |
| Weekly time | 22:00 UTC | 17:00 UTC |

**Source:** [`openedx/envs/common.py`](https://github.com/openedx/openedx-platform/blob/6cb1e4fd65a6841eb7299b0854b5f8676065d087/openedx/envs/common.py#L2693)
```python
NOTIFICATION_DAILY_DIGEST_DELIVERY_HOUR   = 17   # 5 PM UTC
NOTIFICATION_WEEKLY_DIGEST_DELIVERY_DAY   = 0    # Monday
NOTIFICATION_WEEKLY_DIGEST_DELIVERY_HOUR  = 17   # 5 PM UTC
```