### PR TITLE
refactor: migrate enrollment API call from v1 to v2

### DIFF
--- a/src/id-verification/data/service.js
+++ b/src/id-verification/data/service.js
@@ -36,7 +36,7 @@ export async function getExistingIdVerification() {
  * Returns an array: [{...data, mode: String}]
  */
 export async function getEnrollments() {
-  const url = `${getConfig().LMS_BASE_URL}/api/enrollment/v1/enrollment`;
+  const url = `${getConfig().LMS_BASE_URL}/api/enrollment/v2/enrollment/`;
   const requestConfig = {
     headers: { Accept: 'application/json' },
   };

--- a/src/id-verification/data/service.test.js
+++ b/src/id-verification/data/service.test.js
@@ -74,7 +74,7 @@ describe('ID Verification Service', () => {
       const result = await getEnrollments();
 
       expect(mockHttpClient.get).toHaveBeenCalledWith(
-        'http://test.lms/api/enrollment/v1/enrollment',
+        'http://test.lms/api/enrollment/v2/enrollment/',
         { headers: { Accept: 'application/json' } },
       );
       expect(result).toEqual(mockResponse.data);


### PR DESCRIPTION
## Summary

Migrates the ID Verification flow's `getEnrollments()` call from `/api/enrollment/v1/enrollment` to `/api/enrollment/v2/enrollment/`, per the FC-0118 API standardization work on `openedx/edx-platform`.

- `src/id-verification/data/service.js` — endpoint bumped v1 → v2. The trailing slash is required because the v2 endpoint is served by a DRF `DefaultRouter` (`GET /enrollment/`).
- `src/id-verification/data/service.test.js` — updated the expected URL assertion to match.

## Behaviour

Response shape is unchanged (list of enrollments with `mode`), so the downstream verified-mode check is unaffected.

## Dependency

⚠️ Requires the Enrollment v2 API on the LMS (FC-0118, `openedx/edx-platform` PR #38724). Must be released before this is deployed.

## Test plan

- [ ] `npm test` — `service.test.js` passes with the updated assertion
- [ ] Manual: ID verification flow correctly detects verified-mode enrollment against an LMS with v2 enabled

Closes #1445

🤖 Generated with [Claude Code](https://claude.com/claude-code)