### PR TITLE
build: Default the dev MFE config API URL to local.openedx.io

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "build": "fedx-scripts webpack",
-    "dev": "PUBLIC_PATH=/account/ MFE_CONFIG_API_URL='http://localhost:8000/api/mfe_config/v1' fedx-scripts webpack-dev-server --progress --host apps.local.openedx.io",
+    "dev": "PUBLIC_PATH=/account/ MFE_CONFIG_API_URL='http://local.openedx.io:8000/api/mfe_config/v1' fedx-scripts webpack-dev-server --progress --host apps.local.openedx.io",
     "i18n_extract": "fedx-scripts formatjs extract",
     "lint": "fedx-scripts eslint --ext .js --ext .jsx .",
     "lint:fix": "npm run lint -- --fix",


### PR DESCRIPTION
Defaults the `dev` npm script's `MFE_CONFIG_API_URL` to `http://local.openedx.io:8000/api/mfe_config/v1` instead of `http://localhost:8000/...`.

Fetching MFE config from `local.openedx.io` keeps the LMS, Studio, and MFEs under one `*.local.openedx.io` domain, which avoids localhost-specific CORS/cookie carve-outs and better matches a production setup. It works with Tutor dev (whose default LMS host is `local.openedx.io`) and with the upcoming openedx-platform bare-metal `development.py` config.

Motivated by openedx/openedx-platform#37444.
