### PR TITLE
fix: prevent delete account modal from overlapping page footer

### DIFF
--- a/src/account-settings/delete-account/ConfirmationModal.jsx
+++ b/src/account-settings/delete-account/ConfirmationModal.jsx
@@ -78,7 +78,6 @@ export class ConfirmationModal extends Component {
         isOpen={open}
         title={intl.formatMessage(messages['account.settings.delete.account.modal.header'])}
         onClose={onCancel}
-        isOverflowVisible
         footerNode={(
           <ActionRow>
             <Button variant="link" onClick={onCancel}>{intl.formatMessage(messages['account.settings.delete.account.modal.confirm.cancel'])}</Button>

--- a/src/account-settings/delete-account/__snapshots__/ConfirmationModal.test.jsx.snap
+++ b/src/account-settings/delete-account/__snapshots__/ConfirmationModal.test.jsx.snap
@@ -42,7 +42,7 @@ exports[`ConfirmationModal should match empty password confirmation modal snapsh
       />
       <div
         aria-label="Are you sure?"
-        className="pgn__modal pgn__modal-md pgn__modal-default pgn__modal-visible-overflow pgn__alert-modal"
+        className="pgn__modal pgn__modal-md pgn__modal-default pgn__alert-modal"
         role="dialog"
       >
         <div
@@ -273,7 +273,7 @@ exports[`ConfirmationModal should match open confirmation modal snapshot 1`] = `
       />
       <div
         aria-label="Are you sure?"
-        className="pgn__modal pgn__modal-md pgn__modal-default pgn__modal-visible-overflow pgn__alert-modal"
+        className="pgn__modal pgn__modal-md pgn__modal-default pgn__alert-modal"
         role="dialog"
       >
         <div


### PR DESCRIPTION
### Description

Fixes the layout issue in the Delete My Account confirmation modal where the password field and the Cancel / Yes, Delete buttons appeared too low and visually overlapped with the page footer.

#### How Has This Been Tested?

Tested locally, and the screenshots have been updated in the PR description.

#### Screenshots/sandbox (optional):

| Before | After |
| --- | --- |
| <img width="1919" height="855" alt="Before" src="https://github.com/user-attachments/assets/a43c5703-3439-420a-9f04-83e6cb311b2e" /> | <img width="1919" height="855" alt="After" src="https://github.com/user-attachments/assets/c01dbf62-449e-48bf-9d17-057c97f42597" /> |

#### Merge Checklist

- [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
- [x] Is there adequate test coverage for your changes?

#### Post-merge Checklist

- [ ] Deploy the changes to prod after verifying on stage or ask **@jacobo-dominguez-wgu** to do it.
- [ ] 🎉 🙌 Celebrate! Thanks for your contribution.