### PR TITLE
fix: show graceful account settings load error

### DIFF
--- a/src/account-settings/AccountSettingsPage.jsx
+++ b/src/account-settings/AccountSettingsPage.jsx
@@ -833,11 +833,14 @@ class AccountSettingsPage extends React.Component {
 
   renderError() {
     return (
-      <div>
-        {this.props.intl.formatMessage(messages['account.settings.loading.error'], {
-          error: this.props.loadingError,
-        })}
-      </div>
+      <Alert variant="danger">
+        <Alert.Heading>
+          {this.props.intl.formatMessage(messages['account.settings.loading.error.heading'])}
+        </Alert.Heading>
+        <p>
+          {this.props.intl.formatMessage(messages['account.settings.loading.error.body'])}
+        </p>
+      </Alert>
     );
   }
 

--- a/src/account-settings/AccountSettingsPage.messages.jsx
+++ b/src/account-settings/AccountSettingsPage.messages.jsx
@@ -11,10 +11,15 @@ const messages = defineMessages({
     defaultMessage: 'Loading...',
     description: 'Message when data is being loaded',
   },
-  'account.settings.loading.error': {
-    id: 'account.settings.loading.error',
-    defaultMessage: 'Error: {error}',
-    description: 'Message when data failed to load',
+  'account.settings.loading.error.heading': {
+    id: 'account.settings.loading.error.heading',
+    defaultMessage: 'Something went wrong',
+    description: 'Heading for message when account settings fail to load',
+  },
+  'account.settings.loading.error.body': {
+    id: 'account.settings.loading.error.body',
+    defaultMessage: 'We could not load this page. Refresh the page and try again.',
+    description: 'Body message when account settings fail to load',
   },
   'account.settings.banner.beta.language': {
     id: 'account.settings.banner.beta.language',

--- a/src/account-settings/test/AccountSettingsPage.test.jsx
+++ b/src/account-settings/test/AccountSettingsPage.test.jsx
@@ -231,4 +231,23 @@ describe('AccountSettingsPage', () => {
 
     expect(screen.queryByText('We\'re sorry to see you go!')).not.toBeInTheDocument();
   });
+
+  it('renders a graceful loading error message instead of raw error text', () => {
+    store = mockStore({
+      ...mockData,
+      accountSettings: {
+        ...mockData.accountSettings,
+        loading: false,
+        loaded: false,
+        loadingError: 'Missing required request headers: x-enterprise-uuid',
+      },
+    });
+
+    render(reduxWrapper(<AccountSettingsPage {...props} />));
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+    expect(screen.getByText('We could not load this page. Refresh the page and try again.')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /support/ })).not.toBeInTheDocument();
+    expect(screen.queryByText('Missing required request headers: x-enterprise-uuid')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
### Description

Shows a graceful account settings load error instead of exposing raw missing-header error text to users.

#### How Has This Been Tested?

Created a rule in Requestly extension to cancel any request happening to `http://localhost:18000/api/user/v1/accounts/*`, Which throws the similar error and manually verified the fix from the UI as shown the screenshot below.

#### Screenshots/sandbox (optional):
Include a link to the sandbox for design changes or screenshot for before and after. **Remove this section if it's not applicable.**

|Before|After|
|-------|-----|
|<img width="1899" height="857" alt="image" src="https://github.com/user-attachments/assets/88b25906-001a-4045-b843-e4d5337b1890" /> | <img width="1899" height="857" alt="image" src="https://github.com/user-attachments/assets/8aed052d-d195-4380-af55-0ecf42e8f49c" /> |

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@jacobo-dominguez-wgu** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.