### PR TITLE
fix: call backend API for TPA errors

### DIFF
--- a/src/account-settings/AccountSettingsPage.jsx
+++ b/src/account-settings/AccountSettingsPage.jsx
@@ -1,5 +1,5 @@
 import { AppContext } from '@edx/frontend-platform/react';
-import { getConfig, getQueryParameters } from '@edx/frontend-platform';
+import { getConfig } from '@edx/frontend-platform';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -52,17 +52,12 @@ import {
 import { fetchSiteLanguages } from './site-language';
 import { fetchNotificationPreferences } from '../notification-preferences/data/thunks';
 import NotificationSettings from '../notification-preferences/NotificationSettings';
-import { withLocation, withNavigate } from './hoc';
+import { withNavigate } from './hoc';
 import AdditionalProfileFieldsSlot from '../plugin-slots/AdditionalProfileFieldsSlot';
 
 class AccountSettingsPage extends React.Component {
   constructor(props, context) {
     super(props, context);
-
-    const duplicateTpaProvider = getQueryParameters().duplicate_provider;
-    this.state = {
-      duplicateTpaProvider,
-    };
 
     this.navLinkRefs = {
       '#basic-information': React.createRef(),
@@ -240,29 +235,19 @@ class AccountSettingsPage extends React.Component {
     return Boolean(this.props.profileDataManager);
   }
 
-  renderDuplicateTpaProviderMessage() {
-    if (!this.state.duplicateTpaProvider) {
+  renderThirdPartyAuthErrorMessage() {
+    if (!this.props.thirdPartyAuthError) {
       return null;
     }
 
-    // If there is a "duplicate_provider" query parameter, that's the backend's
-    // way of telling us that the provider account the user tried to link is already linked
-    // to another user account on the platform. We use this to display a message to that effect,
-    // and remove the parameter from the URL.
-    this.props.navigate(this.props.location, { replace: true });
-
+    // The LMS records a message when a third-party auth attempt fails (for instance, when the
+    // provider account the user tried to link is already linked to another account) and exposes it
+    // through the third_party_auth_error endpoint. The message is already localized and consumed on
+    // read, so it is only displayed once.
     return (
       <div>
-        <Alert variant="danger">
-          <FormattedMessage
-            id="account.settings.message.duplicate.tpa.provider"
-            defaultMessage="The {provider} account you selected is already linked to another {siteName} account."
-            description="alert message informing the user that the third-party account they attempted to link is already linked to another account"
-            values={{
-              provider: <b>{this.state.duplicateTpaProvider}</b>,
-              siteName: getConfig().SITE_NAME,
-            }}
-          />
+        <Alert variant="danger" icon={Error}>
+          {this.props.thirdPartyAuthError}
         </Alert>
       </div>
     );
@@ -856,7 +841,7 @@ class AccountSettingsPage extends React.Component {
 
     return (
       <Container className="page__account-settings py-5" size="xl">
-        {this.renderDuplicateTpaProviderMessage()}
+        {this.renderThirdPartyAuthErrorMessage()}
         <h1 className="mb-4">
           {this.props.intl.formatMessage(messages['account.settings.page.heading'])}
         </h1>
@@ -952,6 +937,7 @@ AccountSettingsPage.propTypes = {
   tpaProviders: PropTypes.arrayOf(PropTypes.shape({
     connected: PropTypes.bool,
   })),
+  thirdPartyAuthError: PropTypes.string,
   nameChangeModal: PropTypes.oneOfType([
     PropTypes.shape({
       formId: PropTypes.string,
@@ -976,7 +962,6 @@ AccountSettingsPage.propTypes = {
     }),
   ),
   navigate: PropTypes.func.isRequired,
-  location: PropTypes.string.isRequired,
   countriesCodesList: PropTypes.arrayOf(
     PropTypes.shape({
       value: PropTypes.string.isRequired,
@@ -1003,6 +988,7 @@ AccountSettingsPage.defaultProps = {
   profileDataManager: null,
   staticFields: [],
   tpaProviders: [],
+  thirdPartyAuthError: null,
   isActive: true,
   secondary_email_enabled: false,
   nameChangeModal: {} || false,
@@ -1012,7 +998,7 @@ AccountSettingsPage.defaultProps = {
   countriesCodesList: [],
 };
 
-export default withLocation(withNavigate(connect(accountSettingsPageSelector, {
+export default withNavigate(connect(accountSettingsPageSelector, {
   fetchNotificationPreferences,
   fetchSettings,
   saveSettings,
@@ -1020,4 +1006,4 @@ export default withLocation(withNavigate(connect(accountSettingsPageSelector, {
   updateDraft,
   fetchSiteLanguages,
   beginNameChange,
-})(injectIntl(AccountSettingsPage))));
+})(injectIntl(AccountSettingsPage)));

--- a/src/account-settings/data/actions.js
+++ b/src/account-settings/data/actions.js
@@ -24,6 +24,7 @@ export const fetchSettingsBegin = () => ({
 export const fetchSettingsSuccess = ({
   values,
   thirdPartyAuthProviders,
+  thirdPartyAuthError,
   profileDataManager,
   timeZones,
   verifiedNameHistory,
@@ -33,6 +34,7 @@ export const fetchSettingsSuccess = ({
   payload: {
     values,
     thirdPartyAuthProviders,
+    thirdPartyAuthError,
     profileDataManager,
     timeZones,
     verifiedNameHistory,

--- a/src/account-settings/data/reducers.js
+++ b/src/account-settings/data/reducers.js
@@ -36,6 +36,7 @@ export const defaultState = {
   nameChange: nameChangeReducer(),
   thirdPartyAuth: thirdPartyAuthReducer(),
   nameChangeModal: false,
+  thirdPartyAuthError: null,
   verifiedName: null,
   mostRecentVerifiedName: {},
   verifiedNameHistory: {},
@@ -59,6 +60,10 @@ const reducer = (state = defaultState, action = {}) => {
         values: { ...state.values, ...action.payload.values },
         // Dump the providers into thirdPartyAuth.
         thirdPartyAuth: { ...state.thirdPartyAuth, providers: action.payload.thirdPartyAuthProviders },
+        // The LMS consumes the third-party auth message on read, so only the first fetch of a
+        // session returns it. Never let a later fetch (StrictMode's double mount in development,
+        // or any refetch) clobber a message we have already been handed.
+        thirdPartyAuthError: action.payload.thirdPartyAuthError ?? state.thirdPartyAuthError,
         profileDataManager: action.payload.profileDataManager,
         timeZones: action.payload.timeZones,
         loading: false,

--- a/src/account-settings/data/reducers.test.js
+++ b/src/account-settings/data/reducers.test.js
@@ -1,0 +1,44 @@
+import reducer, { defaultState } from './reducers';
+import { fetchSettingsSuccess } from './actions';
+
+const successPayload = (overrides = {}) => ({
+  values: {},
+  thirdPartyAuthProviders: [],
+  thirdPartyAuthError: null,
+  profileDataManager: null,
+  timeZones: [],
+  verifiedNameHistory: {},
+  countriesCodesList: [],
+  ...overrides,
+});
+
+describe('accountSettings reducer', () => {
+  describe('FETCH_SETTINGS.SUCCESS', () => {
+    it('stores the third-party auth error message', () => {
+      const state = reducer(
+        defaultState,
+        fetchSettingsSuccess(successPayload({ thirdPartyAuthError: 'Already linked.' })),
+      );
+
+      expect(state.thirdPartyAuthError).toEqual('Already linked.');
+    });
+
+    it('keeps an already fetched message when a later fetch returns none', () => {
+      // The LMS consumes the message on read, so a second fetch legitimately returns null. The
+      // message must survive it, otherwise StrictMode's double mount hides the alert entirely.
+      const firstFetch = reducer(
+        defaultState,
+        fetchSettingsSuccess(successPayload({ thirdPartyAuthError: 'Already linked.' })),
+      );
+      const secondFetch = reducer(firstFetch, fetchSettingsSuccess(successPayload()));
+
+      expect(secondFetch.thirdPartyAuthError).toEqual('Already linked.');
+    });
+
+    it('leaves the message null when there is none pending', () => {
+      const state = reducer(defaultState, fetchSettingsSuccess(successPayload()));
+
+      expect(state.thirdPartyAuthError).toBeNull();
+    });
+  });
+});

--- a/src/account-settings/data/sagas.js
+++ b/src/account-settings/data/sagas.js
@@ -53,7 +53,7 @@ export function* handleFetchSettings() {
     const { username, userId, roles: userRoles } = getAuthenticatedUser();
 
     const {
-      thirdPartyAuthProviders, profileDataManager, timeZones, countries, ...values
+      thirdPartyAuthProviders, thirdPartyAuthError, profileDataManager, timeZones, countries, ...values
     } = yield call(
       getSettings,
       username,
@@ -68,6 +68,7 @@ export function* handleFetchSettings() {
     yield put(fetchSettingsSuccess({
       values,
       thirdPartyAuthProviders,
+      thirdPartyAuthError,
       profileDataManager,
       timeZones,
       verifiedNameHistory,

--- a/src/account-settings/data/selectors.js
+++ b/src/account-settings/data/selectors.js
@@ -277,6 +277,7 @@ export const accountSettingsPageSelector = createSelector(
     profileDataManager,
     staticFields,
     tpaProviders: accountSettings.thirdPartyAuth.providers,
+    thirdPartyAuthError: accountSettings.thirdPartyAuthError,
     nameChangeModal,
     verifiedName,
     mostRecentVerifiedName,

--- a/src/account-settings/data/service.js
+++ b/src/account-settings/data/service.js
@@ -6,7 +6,7 @@ import omit from 'lodash.omit';
 import isEmpty from 'lodash.isempty';
 
 import { handleRequestError, unpackFieldErrors } from './utils';
-import { getThirdPartyAuthProviders } from '../third-party-auth';
+import { getThirdPartyAuthProviders, getThirdPartyAuthError } from '../third-party-auth';
 import { postVerifiedNameConfig } from '../certificate-preference/data/service';
 import { FIELD_LABELS } from './constants';
 
@@ -215,6 +215,7 @@ export async function getSettings(username, userRoles) {
     account,
     preferences,
     thirdPartyAuthProviders,
+    thirdPartyAuthError,
     profileDataManager,
     timeZones,
     countries,
@@ -222,6 +223,7 @@ export async function getSettings(username, userRoles) {
     getAccount(username),
     getPreferences(username),
     getThirdPartyAuthProviders(),
+    getThirdPartyAuthError(),
     getProfileDataManager(username, userRoles),
     getTimeZones(),
     getCountryList(),
@@ -231,6 +233,7 @@ export async function getSettings(username, userRoles) {
     ...account,
     ...preferences,
     thirdPartyAuthProviders,
+    thirdPartyAuthError,
     profileDataManager,
     timeZones,
     countries,

--- a/src/account-settings/test/AccountSettingsPage.test.jsx
+++ b/src/account-settings/test/AccountSettingsPage.test.jsx
@@ -216,6 +216,28 @@ describe('AccountSettingsPage', () => {
     expect(screen.getByText('We\'re sorry to see you go!')).toBeInTheDocument();
   });
 
+  it('renders the third-party auth error message reported by the LMS', () => {
+    store = mockStore({
+      ...mockData,
+      accountSettings: {
+        ...mockData.accountSettings,
+        thirdPartyAuthError: 'The Google account you selected is already linked to another edX account.',
+      },
+    });
+
+    render(reduxWrapper(<AccountSettingsPage {...props} />));
+
+    expect(
+      screen.getByText('The Google account you selected is already linked to another edX account.'),
+    ).toBeInTheDocument();
+  });
+
+  it('does not render a third-party auth error message when there is none', () => {
+    render(reduxWrapper(<AccountSettingsPage {...props} />));
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
   it('does not render Delete Account section when disabled', () => {
     // eslint-disable-next-line global-require
     const { getConfig } = require('@edx/frontend-platform');

--- a/src/account-settings/third-party-auth/data/service.js
+++ b/src/account-settings/third-party-auth/data/service.js
@@ -15,6 +15,24 @@ export async function getThirdPartyAuthProviders() {
   }));
 }
 
+/**
+ * Retrieve the error message, if any, that the LMS recorded for the last failed third-party auth
+ * attempt (e.g. trying to link a provider account that is already linked to another account).
+ *
+ * The message is consumed on read, so it is only ever returned once. A missing or failing endpoint
+ * is not fatal: the rest of the account settings page must still render.
+ */
+export async function getThirdPartyAuthError() {
+  try {
+    const { data } = await getAuthenticatedHttpClient()
+      .get(`${getConfig().LMS_BASE_URL}/api/user/v1/accounts/third_party_auth_error/`);
+
+    return data.user_message || null;
+  } catch (error) {
+    return null;
+  }
+}
+
 export async function postDisconnectAuth(url) {
   const requestConfig = { headers: { Accept: 'application/json' } };
   const { data } = await getAuthenticatedHttpClient()

--- a/src/account-settings/third-party-auth/data/service.test.js
+++ b/src/account-settings/third-party-auth/data/service.test.js
@@ -1,0 +1,47 @@
+import { getConfig } from '@edx/frontend-platform';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+
+import { getThirdPartyAuthError } from './service';
+
+jest.mock('@edx/frontend-platform');
+jest.mock('@edx/frontend-platform/auth');
+
+const mockHttpClient = {
+  get: jest.fn(),
+  post: jest.fn(),
+};
+
+getAuthenticatedHttpClient.mockReturnValue(mockHttpClient);
+getConfig.mockReturnValue({ LMS_BASE_URL: 'http://lms.test' });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('third party auth service', () => {
+  describe('getThirdPartyAuthError', () => {
+    it('returns the pending user message', async () => {
+      const userMessage = 'The Google account you selected is already linked to another edX account.';
+      mockHttpClient.get.mockResolvedValue({ data: { user_message: userMessage } });
+
+      const result = await getThirdPartyAuthError();
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith(
+        'http://lms.test/api/user/v1/accounts/third_party_auth_error/',
+      );
+      expect(result).toEqual(userMessage);
+    });
+
+    it('returns null when there is no pending message', async () => {
+      mockHttpClient.get.mockResolvedValue({ data: { user_message: '' } });
+
+      expect(await getThirdPartyAuthError()).toBeNull();
+    });
+
+    it('returns null when the request fails', async () => {
+      mockHttpClient.get.mockRejectedValue(new Error('not found'));
+
+      expect(await getThirdPartyAuthError()).toBeNull();
+    });
+  });
+});

--- a/src/account-settings/third-party-auth/index.js
+++ b/src/account-settings/third-party-auth/index.js
@@ -2,5 +2,5 @@
 export { default } from './ThirdPartyAuth';
 export { default as reducer } from './data/reducers';
 export { default as saga } from './data/sagas';
-export { getThirdPartyAuthProviders, postDisconnectAuth } from './data/service';
+export { getThirdPartyAuthProviders, getThirdPartyAuthError, postDisconnectAuth } from './data/service';
 export { DISCONNECT_AUTH } from './data/actions';


### PR DESCRIPTION
### Description

Surfaces third-party auth errors (`SAML / OAuth2 / LTI`) in the Account MFE by consuming the new LMS endpoint, replacing the `duplicate_provider` query parameter that the backend no longer sends.

#### Problem

When a learner links a third-party identity that is already associated with another Open edX account, `python-social-auth` raises `AuthAlreadyAssociated`. The middleware records it as a Django message, but `/account/settings` is a plain redirect to the MFE, which drops Django messages. The backend PR replaces the old `?duplicate_provider=<backend>` redirect param with `GET /api/user/v1/accounts/third_party_auth_error/`.

> [!IMPORTANT]
> This PR depends on the backend implementation https://github.com/openedx/openedx-platform/pull/38673


#### Changes

- `third-party-auth/data/service.js` — new `getThirdPartyAuthError()` calling  `GET /api/user/v1/accounts/third_party_auth_error/`, returning `data.user_message || null`.
- `data/service.js` — added to the existing `getSettings()` `Promise.all`.
- `data/{actions,sagas,reducers,selectors}.js` — carried through the existing `FETCH_SETTINGS` flow into `accountSettings.thirdPartyAuthError`.
- `AccountSettingsPage.jsx` — `renderDuplicateTpaProviderMessage` →  `renderThirdPartyAuthErrorMessage`, rendering the server-supplied message in the same `<Alert variant="danger">` (now with `icon={Error}`, matching the other alerts on the page).

#### Additional information

- **The `?? state.thirdPartyAuthError` guard in the reducer is load-bearing, not defensive  noise.** The endpoint consumes the message on read, and this app runs under React 18  `StrictMode`, which double-mounts in development. The second fetch legitimately returns `null`, and without the guard that `null` overwrote the message, meaning the alert never rendered locally, in exactly the environment used to verify it.
- `withLocation` / the `location` prop were dropped from this page: they existed only to strip the `duplicate_provider` param from the URL, and there is no longer a param to strip.
- Works for any `python-social-auth` error, not only `AuthAlreadyAssociated`.

#### How to test

For testing you must need a TPA configuration + use the backend branch

1. For local testing proposes an `OAuth2ProviderConfig` with `backend_name='dummy'`. `DummyBackend` is already in  `AUTHENTICATION_BACKENDS`, but `Registry._enabled_providers()` is driven by database rows, so  the provider only appears once this row exists:

   ```bash
   docker exec -i <lms-container> python manage.py lms shell -c "
   from django.conf import settings
   from django.contrib.sites.models import Site
   from common.djangoapps.third_party_auth.models import OAuth2ProviderConfig
   from common.djangoapps.third_party_auth.provider import Registry
   from edx_django_utils.cache import TieredCache

   OAuth2ProviderConfig.objects.create(
       enabled=True, name='Dummy', slug='dummy',
       site=Site.objects.get(id=settings.SITE_ID),
       backend_name='dummy', key='dummy-key', secret='dummy-secret',
       visible=True, skip_registration_form=True, skip_email_verification=True,
   )
   # ConfigurationModel.save() does not invalidate the key_values cache that
   # _enabled_providers() reads, so clear it or the provider stays invisible.
   TieredCache.delete_all_tiers(OAuth2ProviderConfig.key_values_cache_key_name('backend_name'))
   print('enabled now:', [p.provider_id for p in Registry.enabled()])
   "
   ```

   Expect `enabled now: ['oa2-dummy']`. Do **not** flush Redis to clear that cache — Open edX
   stores sessions there, so a flush logs out the session under test.

   To reset between runs (the backend hardcodes uid `1234`, so only one account can hold it):

   ```bash
   docker exec -i <lms-container> python manage.py lms shell -c "
   from social_django.models import UserSocialAuth
   print('deleted:', UserSocialAuth.objects.filter(provider='dummy').delete())
   "
   ```

   Teardown: create a superseding row with `enabled=False` (`OAuth2ProviderConfig` is an
   append-only `ConfigurationModel`), then clear the same cache key.

2. Login using the TPA dummy button, that will create a user A associated to the account. 
3. As user B, attempted to link the same identity → `AuthAlreadyAssociated` → redirected to
   `/account/settings` → LMS redirected to the MFE → **the error alert rendered.**
4. Reloaded: alert gone, confirming the consume-on-read contract.
5. Positive path: freed the uid, relinked as user A. No alert, provider shows as connected,
   and `third_party_auth_error/` returned `200 {"user_message": null}` — checked in the Network
   tab rather than inferred from the empty UI, since a failing request would look identical.
6. Endpoint verified directly: first call returns the message, second returns `null`.



#### Screenshots/sandbox (optional):

<img width="1835" height="1055" alt="Screenshot from 2026-08-11 12-02-19" src="https://github.com/user-attachments/assets/d666c73e-7a32-405d-bcdd-e9c5fe453dd2" />


#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@jacobo-dominguez-wgu** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.