### PR TITLE
fix: send 'x' as the social platform id for X (Twitter)

### DIFF
--- a/src/account-settings/data/service.js
+++ b/src/account-settings/data/service.js
@@ -11,7 +11,7 @@ import { postVerifiedNameConfig } from '../certificate-preference/data/service';
 import { FIELD_LABELS } from './constants';
 
 const SOCIAL_PLATFORMS = [
-  { id: 'xTwitter', key: 'social_link_x' },
+  { id: 'x', key: 'social_link_x' },
   { id: 'facebook', key: 'social_link_facebook' },
   { id: 'linkedin', key: 'social_link_linkedin' },
 ];

--- a/src/account-settings/data/service.test.js
+++ b/src/account-settings/data/service.test.js
@@ -38,7 +38,7 @@ describe('account service', () => {
     it('returns unpacked account data', async () => {
       const apiResponse = {
         username: 'testuser',
-        social_links: [{ platform: 'xTwitter', social_link: 'http://t' }],
+        social_links: [{ platform: 'x', social_link: 'http://t' }],
         language_proficiencies: [{ code: 'en' }],
       };
       mockHttpClient.get.mockResolvedValue({ data: apiResponse });
@@ -55,7 +55,7 @@ describe('account service', () => {
       const commit = { social_link_x: 'http://t' };
       const apiResponse = {
         username: 'testuser',
-        social_links: [{ platform: 'xTwitter', social_link: 'http://t' }],
+        social_links: [{ platform: 'x', social_link: 'http://t' }],
         language_proficiencies: [],
       };
       mockHttpClient.patch.mockResolvedValue({ data: apiResponse });
@@ -63,7 +63,7 @@ describe('account service', () => {
       const result = await patchAccount('testuser', commit);
       expect(mockHttpClient.patch).toHaveBeenCalledWith(
         'http://lms.test/api/user/v1/accounts/testuser',
-        expect.objectContaining({ social_links: [{ platform: 'xTwitter', social_link: 'http://t' }] }),
+        expect.objectContaining({ social_links: [{ platform: 'x', social_link: 'http://t' }] }),
         expect.any(Object),
       );
       expect(result.social_link_x).toEqual('http://t');
@@ -174,7 +174,7 @@ describe('account service', () => {
         },
       });
 
-      const result = await patchSettings('user', { time_zone: 'UTC', social_link_twitter: 't' });
+      const result = await patchSettings('user', { time_zone: 'UTC', social_link_x: 't' });
       expect(result.username).toBe('user');
     });
   });

--- a/src/account-settings/test/AccountSettingsPage.test.jsx
+++ b/src/account-settings/test/AccountSettingsPage.test.jsx
@@ -83,7 +83,7 @@ describe('AccountSettingsPage', () => {
         language_proficiencies: 'es',
         social_link_linkedin: 'https://linkedin.com/in/testuser',
         social_link_facebook: '',
-        social_link_twitter: '',
+        social_link_x: '',
         time_zone: 'America/New_York',
         state: 'NY',
         secondary_email_enabled: true,

--- a/src/account-settings/test/mockData.js
+++ b/src/account-settings/test/mockData.js
@@ -24,7 +24,7 @@ const mockData = {
       language_proficiencies: 'es',
       social_link_linkedin: 'https://linkedin.com/in/testuser',
       social_link_facebook: '',
-      social_link_twitter: '',
+      social_link_x: '',
       time_zone: 'America/New_York',
       state: 'NY',
       secondary_email_enabled: true,


### PR DESCRIPTION
#### Original MR to master: https://github.com/openedx/frontend-app-account/pull/1460
--- 

### Description

The Twitter-to-X rename (#1215) changed the platform id sent to the accounts API from `twitter` to `xTwitter`, but `xTwitter` is an i18n message key, not an API value. The accounts API only accepts `facebook`, `x` and `linkedin`, so the X field on the account settings page fails to save with a 400, and an X link set on the profile page (which sends `x`) is never matched when unpacking the account response, leaving the field blank.

Only the platform id was wrong; the `social_link_x` form key introduced by the same change is correct and stays as is. No data migration is needed because `xTwitter` was always rejected by the serializer.

#### How Has This Been Tested?

Sign in as any learner, then:

1. Open the profile page, add an X (Twitter) link (for example `https://www.x.com/openedx`) and save it.
2. Open account settings and scroll to **Social Media Links**. The X (Twitter) field shows the link from step 1 — before this change it was blank.
3. Edit the X (Twitter) field, replace the link with a different one, and save. It saves and the new link is displayed — before this change it failed with "This value is invalid.", and the request came back as a 400 with "The social platform must be facebook, x or linkedin".
4. Reopen the profile page. The X (Twitter) link is the one saved in step 3 — before this change it never arrived, because step 3 could not save.
5. Repeat steps 1-4 with the Facebook and LinkedIn fields — both are expected to behave exactly as before.

Automated: jest 21/21 on the account service and account settings page suites, and eslint clean on the four changed files. Restoring the old `xTwitter` value while keeping the updated assertions fails exactly two tests, one per direction — unpacking the account response and packing the PATCH payload.

#### Screenshots/sandbox:
| Before | After |
|--------|--------|
| <img width="1440" height="3601" alt="02-before-account-save-400" src="https://github.com/user-attachments/assets/0a405f9c-41c0-4887-b745-dcf907efb8d9" /> | <img width="1440" height="3491" alt="02-after-account-save-ok" src="https://github.com/user-attachments/assets/75737090-be98-42f7-ae54-d164922d00bb" /> |
|  <img width="1440" height="1626" alt="03-before-profile-unchanged" src="https://github.com/user-attachments/assets/3aaf4410-b788-4be8-aa01-04dc417951f4" /> | <img width="1440" height="1626" alt="03-after-profile-updated" src="https://github.com/user-attachments/assets/5c929e9d-eeac-4232-a6de-2a9c5ddf5eb4" /> |

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [x] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@jacobo-dominguez-wgu** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
