### PR TITLE
Sort site language dropdown alphabetically

### DIFF
--- a/src/account-settings/site-language/selectors.js
+++ b/src/account-settings/site-language/selectors.js
@@ -12,8 +12,10 @@ export const siteLanguageListSelector = createSelector(
 
 export const siteLanguageOptionsSelector = createSelector(
   siteLanguageSelector,
-  siteLanguage => siteLanguage.siteLanguageList.map(({ code, name }) => ({
-    value: code,
-    label: name,
-  })),
+  siteLanguage => siteLanguage.siteLanguageList
+    .map(({ code, name }) => ({
+      value: code,
+      label: name,
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label)),
 );

--- a/src/account-settings/site-language/selectors.test.js
+++ b/src/account-settings/site-language/selectors.test.js
@@ -1,0 +1,58 @@
+import { siteLanguageListSelector, siteLanguageOptionsSelector, storePath } from './selectors';
+
+const buildState = siteLanguageList => ({
+  accountSettings: {
+    siteLanguage: { siteLanguageList },
+  },
+});
+
+describe('siteLanguageListSelector', () => {
+  it('returns the raw site language list unchanged', () => {
+    const siteLanguageList = [
+      { code: 'fr', name: 'Français' },
+      { code: 'ar', name: 'العربية' },
+    ];
+    const state = buildState(siteLanguageList);
+
+    expect(siteLanguageListSelector(state)).toEqual(siteLanguageList);
+  });
+});
+
+describe('siteLanguageOptionsSelector', () => {
+  it('sorts the options by display name', () => {
+    const state = buildState([
+      { code: 'fr', name: 'Français' },
+      { code: 'ar', name: 'العربية' },
+      { code: 'en', name: 'English' },
+      { code: 'es-419', name: 'Español (Latinoamérica)' },
+    ]);
+
+    expect(siteLanguageOptionsSelector(state)).toEqual([
+      { value: 'en', label: 'English' },
+      { value: 'es-419', label: 'Español (Latinoamérica)' },
+      { value: 'fr', label: 'Français' },
+      { value: 'ar', label: 'العربية' },
+    ]);
+  });
+
+  it('does not mutate the underlying site language list', () => {
+    const siteLanguageList = [
+      { code: 'fr', name: 'Français' },
+      { code: 'ar', name: 'العربية' },
+    ];
+    const state = buildState(siteLanguageList);
+
+    siteLanguageOptionsSelector(state);
+
+    expect(siteLanguageList).toEqual([
+      { code: 'fr', name: 'Français' },
+      { code: 'ar', name: 'العربية' },
+    ]);
+  });
+});
+
+describe('storePath', () => {
+  it('points at the siteLanguage module state', () => {
+    expect(storePath).toEqual(['accountSettings', 'siteLanguage']);
+  });
+});


### PR DESCRIPTION
### Description

The site language dropdown in Account Settings lists languages in whatever order `constants.js` happens to define them, which isn't alphabetical. This sorts `siteLanguageOptionsSelector`'s output by the displayed language name (`localeCompare`) so the dropdown reads in a predictable order.

Fixes #1338.

#### How Has This Been Tested?

Added `selectors.test.js` for the site-language module, covering the sort order and confirming the selector doesn't mutate the underlying `siteLanguageList` array. Ran the new file and the neighboring `data/selectors.test.js` with `fedx-scripts jest`, both green, and linted the changed files with no errors.

#### Merge Checklist

* [x] Is there adequate test coverage for your changes?

---
Drafted with help from Claude (Anthropic); I reviewed the diff and tests and take responsibility for the change.
